### PR TITLE
Fixed: null with missing lamdera compiler

### DIFF
--- a/src/main/kotlin/org/elm/ide/project/ElmWebProjectTemplate.kt
+++ b/src/main/kotlin/org/elm/ide/project/ElmWebProjectTemplate.kt
@@ -55,14 +55,14 @@ class ElmWebProjectTemplate : WebProjectTemplate<Any>(), CustomStepProjectGenera
 
                 // Mark the source roots, etc.
                 with(contentEntry) {
-                    addSourceFolder(join(root.url, "src"), /* test = */ false)
-                    addSourceFolder(join(root.url, DEFAULT_TESTS_DIR_NAME), /* test = */ true)
+                    addSourceFolder(join(root.url, "src"), /* p1 = */ false)
+                    addSourceFolder(join(root.url, DEFAULT_TESTS_DIR_NAME), /* p1 = */ true)
                     addExcludeFolder(join(root.url, "elm-stuff"))
                 }
 
                 rootModel.commit()
-                project.save()
             }
+            project.save()
 
             // attempt to autoconfigure the Elm toolchain and attach `elm.json`.
             asyncAutoDiscoverWorkspace(project, explicitRequest = true).whenCompleteAsync { _, _ ->

--- a/src/main/kotlin/org/elm/openapiext/Subprocesses.kt
+++ b/src/main/kotlin/org/elm/openapiext/Subprocesses.kt
@@ -42,7 +42,6 @@ import java.nio.file.Path
 
 private val log = Logger.getInstance("org.elm.openapiext.Subprocesses")
 
-@Suppress("FunctionName")
 fun GeneralCommandLine(path: Path, vararg args: String) =
     GeneralCommandLine(path.systemIndependentPath, *args)
 

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -27,11 +27,11 @@ data class ElmToolchain(
 ) {
     constructor(elmCompilerPath: String, lamderaCompilerPath: String, elmFormatPath: String, elmTestPath: String, elmReviewPath: String, isElmFormatOnSaveEnabled: Boolean) :
             this(
-                    if (elmCompilerPath.isNotBlank()) Paths.get(elmCompilerPath) else null,
-                    if (lamderaCompilerPath.isNotBlank()) Paths.get(lamderaCompilerPath) else null,
-                    if (elmFormatPath.isNotBlank()) Paths.get(elmFormatPath) else null,
-                    if (elmTestPath.isNotBlank()) Paths.get(elmTestPath) else null,
-                    if (elmReviewPath.isNotBlank()) Paths.get(elmReviewPath) else null,
+                    if (elmCompilerPath.isNotBlank() && Files.exists(Paths.get(elmCompilerPath))) Paths.get(elmCompilerPath) else null,
+                    if (lamderaCompilerPath.isNotBlank() && Files.exists(Paths.get(lamderaCompilerPath))) Paths.get(lamderaCompilerPath) else null,
+                    if (elmFormatPath.isNotBlank() && Files.exists(Paths.get(elmFormatPath))) Paths.get(elmFormatPath) else null,
+                    if (elmTestPath.isNotBlank() && Files.exists(Paths.get(elmTestPath))) Paths.get(elmTestPath) else null,
+                    if (elmReviewPath.isNotBlank() && Files.exists(Paths.get(elmReviewPath))) Paths.get(elmReviewPath) else null,
                     isElmFormatOnSaveEnabled
             )
 

--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -60,6 +60,7 @@ private val log = logger<ElmWorkspaceService>()
  * The state includes user-specific paths, so it is persisted to IntelliJ's workspace file
  * (which is _not_ placed in version control).
  */
+@Service(Service.Level.PROJECT)
 @State(name = "ElmWorkspace", storages = [Storage(StoragePathMacros.WORKSPACE_FILE)])
 class ElmWorkspaceService(val intellijProject: Project) : PersistentStateComponent<Element> {
 
@@ -112,7 +113,7 @@ class ElmWorkspaceService(val intellijProject: Project) : PersistentStateCompone
         }
 
 
-    val rawSettings get() = rawSettingsRef.get()
+    val rawSettings: RawSettings? get() = rawSettingsRef.get()
 
 
     private val rawSettingsRef = AtomicReference(RawSettings())
@@ -461,7 +462,7 @@ class ElmWorkspaceService(val intellijProject: Project) : PersistentStateCompone
         val isElmFormatOnSaveEnabled = settingsElement
             .getAttributeValue("isElmFormatOnSaveEnabled")
             .takeIf { it != null && it.isNotBlank() }?.toBoolean()
-            ?: ElmToolchain.DEFAULT_FORMAT_ON_SAVE
+            ?: DEFAULT_FORMAT_ON_SAVE
 
         modifySettings(notify = false) {
             RawSettings(

--- a/src/main/kotlin/org/elm/workspace/ui/ElmWorkspaceConfigurable.kt
+++ b/src/main/kotlin/org/elm/workspace/ui/ElmWorkspaceConfigurable.kt
@@ -297,19 +297,29 @@ class ElmWorkspaceConfigurable(
 
     override fun reset() {
         val settings = project.elmWorkspace.rawSettings
-        val elmCompilerPath = settings.elmCompilerPath
-        val lamderaCompilerPath = settings.lamderaCompilerPath
-        val elmFormatPath = settings.elmFormatPath
-        val isElmFormatOnSaveEnabled = settings.isElmFormatOnSaveEnabled
-        val elmTestPath = settings.elmTestPath
-        val elmReviewPath = settings.elmReviewPath
+        val elmCompilerPath = settings?.elmCompilerPath
+        val lamderaCompilerPath = settings?.lamderaCompilerPath
+        val elmFormatPath = settings?.elmFormatPath
+        val isElmFormatOnSaveEnabled = settings?.isElmFormatOnSaveEnabled
+        val elmTestPath = settings?.elmTestPath
+        val elmReviewPath = settings?.elmReviewPath
 
-        elmPathField.text = elmCompilerPath
-        lamderaPathField.text = lamderaCompilerPath
-        elmFormatPathField.text = elmFormatPath
-        elmFormatOnSaveCheckbox.isSelected = isElmFormatOnSaveEnabled
-        elmTestPathField.text = elmTestPath
-        elmReviewPathField.text = elmReviewPath
+        if (elmCompilerPath != null) {
+            elmPathField.text = elmCompilerPath
+        }
+        if (lamderaCompilerPath != null) {
+            lamderaPathField.text = lamderaCompilerPath
+        }
+        if (elmFormatPath != null) {
+            elmFormatPathField.text = elmFormatPath
+        }
+        elmFormatOnSaveCheckbox.isSelected = isElmFormatOnSaveEnabled == true
+        if (elmTestPath != null) {
+            elmTestPathField.text = elmTestPath
+        }
+        if (elmReviewPath != null) {
+            elmReviewPathField.text = elmReviewPath
+        }
 
         update()
     }
@@ -331,7 +341,7 @@ class ElmWorkspaceConfigurable(
 
     override fun isModified(): Boolean {
         val settings = project.elmWorkspace.rawSettings
-        return elmPathField.text != settings.elmCompilerPath
+        return elmPathField.text != settings?.elmCompilerPath
                 || lamderaPathField.text != settings.lamderaCompilerPath
                 || elmFormatPathField.text != settings.elmFormatPath
                 || elmTestPathField.text != settings.elmTestPath

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
     <!-- Changing the ID will prohibit upgrades of version of the plugin with a previous ID. -->
     <id>intellij-elm</id>
     <name>Elm</name>
-    <vendor url="https://github.com/intellij-elm">The Elm Plugin Contributors</vendor>
+    <vendor url="https://github.com/elm-tooling/">The Elm Plugin Contributors</vendor>
 
     <description><![CDATA[
         Provides support for the <a href="http://elm-lang.org">Elm programming language</a>.<br/>
@@ -220,7 +220,6 @@
         </intentionAction>
 
         <!-- ELM PROJECTS, PACKAGES AND DEPENDENCIES -->
-        <projectService serviceImplementation="org.elm.workspace.ElmWorkspaceService"/>
         <additionalLibraryRootsProvider implementation="org.elm.workspace.ElmAdditionalLibraryRootsProvider"/>
         <projectConfigurable instance="org.elm.workspace.ui.ElmWorkspaceConfigurable" displayName="Elm"
                              groupId="language"/>


### PR DESCRIPTION
This fixes the various paths for the settings to ensure that the paths exist before setting them.

It also contains a few automated fixes suggested by the IDE to upgrade some parts to the latest methods. Specifically, an error was being raised on doing `project.save()` within a write action. ChatGPT suggested moving the `project.save()` call outside of the write action, which seems to have fixed it.

Updated the github repo in the plugin.xml file as well.

Should fix #3.