### PR TITLE
Set locale for ElmColorProvider

### DIFF
--- a/src/main/kotlin/org/elm/ide/color/ElmColorProvider.kt
+++ b/src/main/kotlin/org/elm/ide/color/ElmColorProvider.kt
@@ -11,6 +11,7 @@ import org.elm.lang.core.psi.ElmTypes.REGULAR_STRING_PART
 import org.elm.lang.core.psi.elementType
 import org.elm.lang.core.psi.elements.*
 import java.awt.Color
+import java.util.Locale
 import kotlin.math.roundToInt
 
 private val colorRegex = Regex("""#[0-9a-fA-F]{3,8}\b|\b(?:rgb|hsl)a?\([^)]+\)""")
@@ -197,5 +198,5 @@ private fun Color.toRGB() = RGB(red, green, blue, alpha / 255f)
 private fun Float.render(): String = when (this) {
     0f -> "0"
     1f -> "1"
-    else -> String.format("%.4f", this).trimEnd('0').trimEnd('.')
+    else -> String.format(Locale.ENGLISH, "%.4f", this).trimEnd('0').trimEnd('.')
 }

--- a/src/test/kotlin/org/elm/ide/color/ElmColorProviderTest.kt
+++ b/src/test/kotlin/org/elm/ide/color/ElmColorProviderTest.kt
@@ -13,176 +13,176 @@ import org.junit.Test
 class ElmColorProviderTest : ElmTestBase() {
 
     @Test
-    fun `test value with other string content (flaky)`() = doGutterTest(1, """
+    fun `test value with other string content`() = doGutterTest(1, """
 main = ("border", "1px solid #aabbcc")
 """)
 
     // format test cases from https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
 
     @Test
-    fun `test #f09 (flaky)`() = doFormatTest("#f09")
+    fun `test #f09`() = doFormatTest("#f09")
 
     @Test
-    fun `test #F09 (flaky)`() = doFormatTest("#F09")
+    fun `test #F09`() = doFormatTest("#F09")
 
     @Test
-    fun `test #ff0099 (flaky)`() = doFormatTest("#ff0099")
+    fun `test #ff0099`() = doFormatTest("#ff0099")
 
     @Test
-    fun `test #FF0099 (flaky)`() = doFormatTest("#FF0099")
+    fun `test #FF0099`() = doFormatTest("#FF0099")
 
     @Test
-    fun `test rgb(255,0,153) (flaky)`() = doFormatTest("rgb(255,0,153)")
+    fun `test rgb(255,0,153)`() = doFormatTest("rgb(255,0,153)")
 
     @Test
-    fun `test rgb(255, 0, 153) (flaky)`() = doFormatTest("rgb(255, 0, 153)")
+    fun `test rgb(255, 0, 153)`() = doFormatTest("rgb(255, 0, 153)")
 
     @Test
-    fun `test rgb(255, 0, 153_0) (flaky)`() = doFormatTest("rgb(255, 0, 153.0)")
+    fun `test rgb(255, 0, 153_0)`() = doFormatTest("rgb(255, 0, 153.0)")
 
     @Test
-    fun `test rgb(100%,0%,60%) (flaky)`() = doFormatTest("rgb(100%,0%,60%)")
+    fun `test rgb(100%,0%,60%)`() = doFormatTest("rgb(100%,0%,60%)")
 
     @Test
-    fun `test rgb(100%, 0%, 60%) (flaky)`() = doFormatTest("rgb(100%, 0%, 60%)")
+    fun `test rgb(100%, 0%, 60%)`() = doFormatTest("rgb(100%, 0%, 60%)")
 
     @Test
-    fun `test rgb(255 0 153) (flaky)`() = doFormatTest("rgb(255 0 153)")
+    fun `test rgb(255 0 153)`() = doFormatTest("rgb(255 0 153)")
 
     @Test
-    fun `test #f09f (flaky)`() = doFormatTest("#f09f")
+    fun `test #f09f`() = doFormatTest("#f09f")
 
     @Test
-    fun `test #F09F (flaky)`() = doFormatTest("#F09F")
+    fun `test #F09F`() = doFormatTest("#F09F")
 
     @Test
-    fun `test #ff0099ff (flaky)`() = doFormatTest("#ff0099ff")
+    fun `test #ff0099ff`() = doFormatTest("#ff0099ff")
 
     @Test
-    fun `test #FF0099FF (flaky)`() = doFormatTest("#FF0099FF")
+    fun `test #FF0099FF`() = doFormatTest("#FF0099FF")
 
     @Test
-    fun `test rgb(255, 0, 153, 1) (flaky)`() = doFormatTest("rgb(255, 0, 153, 1)")
+    fun `test rgb(255, 0, 153, 1)`() = doFormatTest("rgb(255, 0, 153, 1)")
 
     @Test
-    fun `test rgb(255, 0, 153, 100%) (flaky)`() = doFormatTest("rgb(255, 0, 153, 100%)")
+    fun `test rgb(255, 0, 153, 100%)`() = doFormatTest("rgb(255, 0, 153, 100%)")
 
     @Test
-    fun `test rgb(255 0 153 _ 1) (flaky)`() = doFormatTest("rgb(255 0 153 / 1)")
+    fun `test rgb(255 0 153 _ 1)`() = doFormatTest("rgb(255 0 153 / 1)")
 
     @Test
-    fun `test rgb(255 0 153 _ 100%) (flaky)`() = doFormatTest("rgb(255 0 153 / 100%)")
+    fun `test rgb(255 0 153 _ 100%)`() = doFormatTest("rgb(255 0 153 / 100%)")
 
     @Test
-    fun `test rgb(255, 0, 153_6, 1) (flaky)`() = doFormatTest("rgb(255, 0, 153.6, 1)")
+    fun `test rgb(255, 0, 153_6, 1)`() = doFormatTest("rgb(255, 0, 153.6, 1)")
 
     @Test
-    fun `test rgb(1e2, _5e1, _5e0, +_25e2%) (flaky)`() = doFormatTest("rgb(1e2, .5e1, .5e0, +.25e2%)")
+    fun `test rgb(1e2, _5e1, _5e0, +_25e2%)`() = doFormatTest("rgb(1e2, .5e1, .5e0, +.25e2%)")
 
     @Test
-    fun `test hsl(270,60%,70%) (flaky)`() = doFormatTest("hsl(270,60%,70%)")
+    fun `test hsl(270,60%,70%)`() = doFormatTest("hsl(270,60%,70%)")
 
     @Test
-    fun `test hsl(270, 60%, 70%) (flaky)`() = doFormatTest("hsl(270, 60%, 70%)")
+    fun `test hsl(270, 60%, 70%)`() = doFormatTest("hsl(270, 60%, 70%)")
 
     @Test
-    fun `test hsl(270 60% 70%) (flaky)`() = doFormatTest("hsl(270 60% 70%)")
+    fun `test hsl(270 60% 70%)`() = doFormatTest("hsl(270 60% 70%)")
 
     @Test
-    fun `test hsl(270deg, 60%, 70%) (flaky)`() = doFormatTest("hsl(270deg, 60%, 70%)")
+    fun `test hsl(270deg, 60%, 70%)`() = doFormatTest("hsl(270deg, 60%, 70%)")
 
     @Test
-    fun `test hsl(4_71239rad, 60%, 70%) (flaky)`() = doFormatTest("hsl(4.71239rad, 60%, 70%)")
+    fun `test hsl(4_71239rad, 60%, 70%)`() = doFormatTest("hsl(4.71239rad, 60%, 70%)")
 
     @Test
-    fun `test hsl(_75turn, 60%, 70%) (flaky)`() = doFormatTest("hsl(.75turn, 60%, 70%)")
+    fun `test hsl(_75turn, 60%, 70%)`() = doFormatTest("hsl(.75turn, 60%, 70%)")
 
     @Test
-    fun `test hsl(270, 60%, 50%, _15) (flaky)`() = doFormatTest("hsl(270, 60%, 50%, .15)")
+    fun `test hsl(270, 60%, 50%, _15)`() = doFormatTest("hsl(270, 60%, 50%, .15)")
 
     @Test
-    fun `test hsl(270, 60%, 50%, 15%) (flaky)`() = doFormatTest("hsl(270, 60%, 50%, 15%)")
+    fun `test hsl(270, 60%, 50%, 15%)`() = doFormatTest("hsl(270, 60%, 50%, 15%)")
 
     @Test
-    fun `test hsl(270 60% 50% _ _15) (flaky)`() = doFormatTest("hsl(270 60% 50% / .15)")
+    fun `test hsl(270 60% 50% _ _15)`() = doFormatTest("hsl(270 60% 50% / .15)")
 
     @Test
-    fun `test hsl(270 60% 50% _ 15%) (flaky)`() = doFormatTest("hsl(270 60% 50% / 15%)")
+    fun `test hsl(270 60% 50% _ 15%)`() = doFormatTest("hsl(270 60% 50% / 15%)")
 
     @Test
-    fun `test write #f09 (flaky)`() = doCssWriteTest("#f09", "#7b2d43")
+    fun `test write #f09`() = doCssWriteTest("#f09", "#7b2d43")
 
     @Test
-    fun `test write #ff0099 (flaky)`() = doCssWriteTest("#ff0099", "#7b2d43")
+    fun `test write #ff0099`() = doCssWriteTest("#ff0099", "#7b2d43")
 
     @Test
-    fun `test write rgb(255,0,153) (flaky)`() = doCssWriteTest("rgb(255,0,153)", "rgb(123, 45, 67)")
+    fun `test write rgb(255,0,153)`() = doCssWriteTest("rgb(255,0,153)", "rgb(123, 45, 67)")
 
     @Test
-    fun `test write rgb(255, 0, 153) (flaky)`() = doCssWriteTest("rgb(255, 0, 153)", "rgb(123, 45, 67)")
+    fun `test write rgb(255, 0, 153)`() = doCssWriteTest("rgb(255, 0, 153)", "rgb(123, 45, 67)")
 
     @Test
-    fun `test write rgb(255, 0, 153_0) (flaky)`() = doCssWriteTest("rgb(255, 0, 153.0)", "rgb(123, 45, 67)")
+    fun `test write rgb(255, 0, 153_0)`() = doCssWriteTest("rgb(255, 0, 153.0)", "rgb(123, 45, 67)")
 
     @Test
-    fun `test write rgb(100%,0%,60%) (flaky)`() = doCssWriteTest("rgb(100%,0%,60%)", "rgb(48%, 18%, 26%)")
+    fun `test write rgb(100%,0%,60%)`() = doCssWriteTest("rgb(100%,0%,60%)", "rgb(48%, 18%, 26%)")
 
     @Test
-    fun `test write rgb(100%, 0%, 60%) (flaky)`() = doCssWriteTest("rgb(100%, 0%, 60%)", "rgb(48%, 18%, 26%)")
+    fun `test write rgb(100%, 0%, 60%)`() = doCssWriteTest("rgb(100%, 0%, 60%)", "rgb(48%, 18%, 26%)")
 
     @Test
-    fun `test write rgb(255 0 153) (flaky)`() = doCssWriteTest("rgb(255 0 153)", "rgb(123 45 67)")
+    fun `test write rgb(255 0 153)`() = doCssWriteTest("rgb(255 0 153)", "rgb(123 45 67)")
 
     @Test
-    fun `test write #f090 (flaky)`() = doCssWriteTest("#f090", "#7b2d4300", RGB(123, 45, 67, 0f))
+    fun `test write #f090`() = doCssWriteTest("#f090", "#7b2d4300", RGB(123, 45, 67, 0f))
 
     @Test
-    fun `test write #ff009900 (flaky)`() = doCssWriteTest("#ff00990", "#7b2d4300", RGB(123, 45, 67, 0f))
+    fun `test write #ff009900`() = doCssWriteTest("#ff00990", "#7b2d4300", RGB(123, 45, 67, 0f))
 
     @Test
-    fun `test write rgba(255, 0, 153, 1) (flaky)`() = doCssWriteTest("rgba(255, 0, 153, 1)", "rgba(123, 45, 67)")
+    fun `test write rgba(255, 0, 153, 1)`() = doCssWriteTest("rgba(255, 0, 153, 1)", "rgba(123, 45, 67)")
 
     @Test
-    fun `test write rgb(255, 0, 153, 100%) (flaky)`() = doCssWriteTest("rgb(255, 0, 153, 100%)", "rgb(123, 45, 67, 50%)", RGB(123, 45, 67, .5f))
+    fun `test write rgb(255, 0, 153, 100%)`() = doCssWriteTest("rgb(255, 0, 153, 100%)", "rgb(123, 45, 67, 50%)", RGB(123, 45, 67, .5f))
 
     @Test
-    fun `test write rgb(255 0 153 _ 1) (flaky)`() = doCssWriteTest("rgb(255 0 153 / 1)", "rgb(123 45 67 / .2)", RGB(123, 45, 67, .2f))
+    fun `test write rgb(255 0 153 _ 1)`() = doCssWriteTest("rgb(255 0 153 / 1)", "rgb(123 45 67 / .2)", RGB(123, 45, 67, .2f))
 
     @Test
-    fun `test write rgb(255 0 153 _ 100%) (flaky)`() = doCssWriteTest("rgb(255 0 153 / 100%)", "rgb(123 45 67 / 50%)", RGB(123, 45, 67, .5f))
+    fun `test write rgb(255 0 153 _ 100%)`() = doCssWriteTest("rgb(255 0 153 / 100%)", "rgb(123 45 67 / 50%)", RGB(123, 45, 67, .5f))
 
     @Test
-    fun `test write hsl(270,60%,70%) (flaky)`() = doCssWriteTest("hsl(270,60%,70%)", "hsl(123, 45%, 67%, .2)", HSL(123, 45, 67, .2f))
+    fun `test write hsl(270,60%,70%)`() = doCssWriteTest("hsl(270,60%,70%)", "hsl(123, 45%, 67%, .2)", HSL(123, 45, 67, .2f))
 
     @Test
-    fun `test write hsl(270, 60%, 70%) (flaky)`() = doCssWriteTest("hsl(270, 60%, 70%)", "hsl(123, 45%, 67%)", HSL(123, 45, 67))
+    fun `test write hsl(270, 60%, 70%)`() = doCssWriteTest("hsl(270, 60%, 70%)", "hsl(123, 45%, 67%)", HSL(123, 45, 67))
 
     @Test
-    fun `test write hsl(270 60% 70%) (flaky)`() = doCssWriteTest("hsl(270 60% 70%)", "hsl(123 45% 67%)", HSL(123, 45, 67))
+    fun `test write hsl(270 60% 70%)`() = doCssWriteTest("hsl(270 60% 70%)", "hsl(123 45% 67%)", HSL(123, 45, 67))
 
     @Test
-    fun `test write hsl(270, 60%, 50%, _15) (flaky)`() = doCssWriteTest("hsl(270, 60%, 50%, .15)", "hsl(123, 45%, 67%, .2)", HSL(123, 45, 67, .2f))
+    fun `test write hsl(270, 60%, 50%, _15)`() = doCssWriteTest("hsl(270, 60%, 50%, .15)", "hsl(123, 45%, 67%, .2)", HSL(123, 45, 67, .2f))
 
     @Test
-    fun `test write hsl(270, 60%, 50%, 15%) (flaky)`() = doCssWriteTest("hsl(270, 60%, 50%, 15%)", "hsl(123, 45%, 67%, 20%)", HSL(123, 45, 67, .2f))
+    fun `test write hsl(270, 60%, 50%, 15%)`() = doCssWriteTest("hsl(270, 60%, 50%, 15%)", "hsl(123, 45%, 67%, 20%)", HSL(123, 45, 67, .2f))
 
     @Test
-    fun `test write hsl(270 60% 50% _ _15) (flaky)`() = doCssWriteTest("hsl(270 60% 50% / .15)", "hsl(123 45% 67% / .2)", HSL(123, 45, 67, .2f))
+    fun `test write hsl(270 60% 50% _ _15)`() = doCssWriteTest("hsl(270 60% 50% / .15)", "hsl(123 45% 67% / .2)", HSL(123, 45, 67, .2f))
 
     @Test
-    fun `test write hsl(270 60% 50% _ 15%) (flaky)`() = doCssWriteTest("hsl(270 60% 50% / 15%)", "hsl(123 45% 67% / 20%)", HSL(123, 45, 67, .2f))
+    fun `test write hsl(270 60% 50% _ 15%)`() = doCssWriteTest("hsl(270 60% 50% / 15%)", "hsl(123 45% 67% / 20%)", HSL(123, 45, 67, .2f))
 
     @Test
-    fun `test write hsl(270grad,60%,70%) (flaky)`() = doCssWriteTest("hsl(270grad,60%,70%)", "hsl(136.6666grad, 45%, 67%, .2)", HSL(123, 45, 67, .2f))
+    fun `test write hsl(270grad,60%,70%)`() = doCssWriteTest("hsl(270grad,60%,70%)", "hsl(136.6666grad, 45%, 67%, .2)", HSL(123, 45, 67, .2f))
 
     @Test
-    fun `test write hsl(270rad,60%,70%) (flaky)`() = doCssWriteTest("hsl(270rad,60%,70%)", "hsl(2.1467rad, 45%, 67%, .2)", HSL(123, 45, 67, .2f))
+    fun `test write hsl(270rad,60%,70%)`() = doCssWriteTest("hsl(270rad,60%,70%)", "hsl(2.1467rad, 45%, 67%, .2)", HSL(123, 45, 67, .2f))
 
     @Test
-    fun `test write hsl(270turn,60%,70%) (flaky)`() = doCssWriteTest("hsl(270turn,60%,70%)", "hsl(.3416turn, 45%, 67%, .2)", HSL(123, 45, 67, .2f))
+    fun `test write hsl(270turn,60%,70%)`() = doCssWriteTest("hsl(270turn,60%,70%)", "hsl(.3416turn, 45%, 67%, .2)", HSL(123, 45, 67, .2f))
 
     @Test
-    fun `test rgb int read (flaky)`() = doGutterTest(2, """
+    fun `test rgb int read`() = doGutterTest(2, """
 type Color = Color
 rgb : Int -> Int -> Int -> Color
 rgb r g b = Color
@@ -197,7 +197,7 @@ main =
 """)
 
     @Test
-    fun `test rgba int read (flaky)`() = doGutterTest(3, """
+    fun `test rgba int read`() = doGutterTest(3, """
 type Color = Color
 rgba : Int -> Int -> Int -> Float -> Color
 rgba r g b a = Color
@@ -211,7 +211,7 @@ main =
 """)
 
     @Test
-    fun `test rgb255 int read (flaky)`() = doGutterTest(2, """
+    fun `test rgb255 int read`() = doGutterTest(2, """
 type Color = Color
 rgb255 : Int -> Int -> Int -> Color
 rgb255 r g b = Color
@@ -223,7 +223,7 @@ main =
 """)
 
     @Test
-    fun `test rgb float read (flaky)`() = doGutterTest(3, """
+    fun `test rgb float read`() = doGutterTest(3, """
 type Color = Color
 rgb : Float -> Float -> Float -> Color
 rgb r g b = Color
@@ -237,7 +237,7 @@ main =
 """)
 
     @Test
-    fun `test rgba float read (flaky)`() = doGutterTest(3, """
+    fun `test rgba float read`() = doGutterTest(3, """
 type Color = Color
 rgba : Float -> Float -> Float -> Float -> Color
 rgba r g b a = Color
@@ -251,7 +251,7 @@ main =
 """)
 
     @Test
-    fun `test hsl read (flaky)`() = doGutterTest(3, """
+    fun `test hsl read`() = doGutterTest(3, """
 type Color = Color
 hsl : Float -> Float -> Float -> Color
 rgb h s l = Color
@@ -266,7 +266,7 @@ main =
 """)
 
     @Test
-    fun `test hsla read (flaky)`() = doGutterTest(3, """
+    fun `test hsla read`() = doGutterTest(3, """
 type Color = Color
 hsla : Float -> Float -> Float -> Float -> Color
 hsla h s l a = Color
@@ -280,49 +280,49 @@ main =
 """)
 
     @Test
-    fun `test write rgb 0 0 0 (flaky)`() = doFuncWriteTest("rgb", "0 0 0", "123 45 67")
+    fun `test write rgb 0 0 0`() = doFuncWriteTest("rgb", "0 0 0", "123 45 67")
 
     @Test
-    fun `test write rgb 255 255 255 (flaky)`() = doFuncWriteTest("rgb", "255 255 255", "123 45 67")
+    fun `test write rgb 255 255 255`() = doFuncWriteTest("rgb", "255 255 255", "123 45 67")
 
     @Test
-    fun `test write rgb 0 0 0 with alpha (flaky)`() = doFuncWriteTest("rgb", "0 0 0", "123 45 67", RGB(123, 45, 67, .5f))
+    fun `test write rgb 0 0 0 with alpha`() = doFuncWriteTest("rgb", "0 0 0", "123 45 67", RGB(123, 45, 67, .5f))
 
     @Test
-    fun `test write rgb255 0 0 0 (flaky)`() = doFuncWriteTest("rgb255", "0 0 0", "123 45 67")
+    fun `test write rgb255 0 0 0`() = doFuncWriteTest("rgb255", "0 0 0", "123 45 67")
 
     @Test
-    fun `test write rgba 0 0 0 0 (flaky)`() = doFuncWriteTest("rgba", "0 0 0 0", "123 45 67 1")
+    fun `test write rgba 0 0 0 0`() = doFuncWriteTest("rgba", "0 0 0 0", "123 45 67 1")
 
     @Test
-    fun `test write rgba 255 255 255 1 (flaky)`() = doFuncWriteTest("rgba", "255 255 255 1", "123 45 67 0.2", RGB(123, 45, 67, .2f))
+    fun `test write rgba 255 255 255 1`() = doFuncWriteTest("rgba", "255 255 255 1", "123 45 67 0.2", RGB(123, 45, 67, .2f))
 
     @Test
-    fun `test write rgb float 1 1 1 (flaky)`() = doFuncWriteTest("rgb", "1 1 1", "0.4824 0.1765 0.2627")
+    fun `test write rgb float 1 1 1`() = doFuncWriteTest("rgb", "1 1 1", "0.4824 0.1765 0.2627")
 
     @Test
-    fun `test write rgb float 0_5 0_5 0_5 (flaky)`() = doFuncWriteTest("rgb", "0.5 0.5 05", "0.4824 0.1765 0.2627")
+    fun `test write rgb float 0_5 0_5 0_5`() = doFuncWriteTest("rgb", "0.5 0.5 05", "0.4824 0.1765 0.2627")
 
     @Test
-    fun `test write rgba 1 1 1 1 (flaky)`() = doFuncWriteTest("rgba", "1 1 1 1", "0.4824 0.1765 0.2627 1")
+    fun `test write rgba 1 1 1 1`() = doFuncWriteTest("rgba", "1 1 1 1", "0.4824 0.1765 0.2627 1")
 
     @Test
-    fun `test write rgba float (flaky)`() = doFuncWriteTest("rgba", "0.5 0.5 05 0.5", "0.4824 0.1765 0.2627 1")
+    fun `test write rgba float`() = doFuncWriteTest("rgba", "0.5 0.5 05 0.5", "0.4824 0.1765 0.2627 1")
 
     @Test
-    fun `test write hsl 0 0 0 (flaky)`() = doFuncWriteTest("hsl", "0 0 0", "0 0 0", HSL(0, 0, 0))
+    fun `test write hsl 0 0 0`() = doFuncWriteTest("hsl", "0 0 0", "0 0 0", HSL(0, 0, 0))
 
     @Test
-    fun `test write hsl 360 1 1 (flaky)`() = doFuncWriteTest("hsl", "360 1 1", "180 0.5 0.5", HSL(180, 50, 50))
+    fun `test write hsl 360 1 1`() = doFuncWriteTest("hsl", "360 1 1", "180 0.5 0.5", HSL(180, 50, 50))
 
     @Test
-    fun `test write hsla 0 0 0 0 (flaky)`() = doFuncWriteTest("hsla", "0 0 0 0", "0 0 0 1", HSL(0, 0, 0))
+    fun `test write hsla 0 0 0 0`() = doFuncWriteTest("hsla", "0 0 0 0", "0 0 0 1", HSL(0, 0, 0))
 
     @Test
-    fun `test write hsla 360 1 1 1 (flaky)`() = doFuncWriteTest("hsla", "360 1 1 1", "180 0.5 0.5 0.2", HSL(180, 50, 50, .2f))
+    fun `test write hsla 360 1 1 1`() = doFuncWriteTest("hsla", "360 1 1 1", "180 0.5 0.5 0.2", HSL(180, 50, 50, .2f))
 
     @Test
-    fun `test write rgb with linebreaks and comments (flaky)`() = doWriteTest(RGB(123, 45, 67), """
+    fun `test write rgb with linebreaks and comments`() = doWriteTest(RGB(123, 45, 67), """
 main = rgb{-caret-}
     -- red
     2 --


### PR DESCRIPTION
When running the tests on a system with non-English locale, a lot of test cases in ElmColorProviderTest were failing. This fixes those tests by specifying the locale in the String.format call to english so the float delimiter is correct.

I also removed the `(flaky)` note from all the test cases in ElmColorProviderTest since my hope is that this was the cause for the flakiness and since the tests are working in the CI pipeline.
