### PR TITLE
fix remaining broken tests

### DIFF
--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceServiceTest.kt
@@ -1,5 +1,6 @@
 package org.elm.workspace
 
+import com.intellij.testFramework.PlatformTestUtil
 import junit.framework.TestCase
 import org.elm.fileTree
 import org.elm.openapiext.elementFromXmlString
@@ -270,6 +271,7 @@ class ElmWorkspaceServiceTest : ElmWorkspaceTestBase() {
 
         // ... must be able to load from serialized state ...
         workspace.asyncLoadState(elementFromXmlString(xml)).get()
+        PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()
         val actualProjects = workspace.allProjects.map { it.manifestPath }
         val expectedProjects = listOf(projectPath)
         checkEquals(expectedProjects, actualProjects)

--- a/src/test/resources/org/elm/lang/core/parser/fixtures/partial/LetIn.txt
+++ b/src/test/resources/org/elm/lang/core/parser/fixtures/partial/LetIn.txt
@@ -22,7 +22,7 @@ Elm File
       PsiWhiteSpace('\n')
       PsiElement(VIRTUAL_OPEN_SECTION)('        ')
       PsiElement(LOWER_CASE_IDENTIFIER)('x')
-      PsiErrorElement:COLON, EQ, LEFT_BRACE, LEFT_PARENTHESIS, LEFT_SQUARE_BRACKET, LOWER_CASE_IDENTIFIER, NUMBER_LITERAL, OPEN_CHAR, OPEN_QUOTE or UNDERSCORE expected
+      PsiErrorElement:<pattern>, COLON, EQ, LEFT_BRACE, LEFT_PARENTHESIS, LEFT_SQUARE_BRACKET, LOWER_CASE_IDENTIFIER, NUMBER_LITERAL, OPEN_CHAR, OPEN_QUOTE or UNDERSCORE expected
         <empty list>
       PsiErrorElement:IN expected
         <empty list>


### PR DESCRIPTION
This fixes the two remaining broken tests:

```
ElmPartialParsingTestCase > testLetIn FAILED
    com.intellij.rt.execution.junit.FileComparisonFailure at ElmPartialParsingTestCase.kt:95

ElmWorkspaceServiceTest > test persistence roundtrip FAILED
    com.intellij.util.lang.CompoundRuntimeException at RunAll.kt:30
        Caused by: com.intellij.serviceContainer.AlreadyDisposedException at containerUtil.kt:40
```