### PR TITLE
Switch to non-deprecated DelayedDocumentWatcher constructor

### DIFF
--- a/src/main/kotlin/org/elm/ide/test/run/ElmTestAutoTestManager.kt
+++ b/src/main/kotlin/org/elm/ide/test/run/ElmTestAutoTestManager.kt
@@ -5,10 +5,9 @@ import com.intellij.execution.testframework.autotest.DelayedDocumentWatcher
 import com.intellij.openapi.components.*
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.Condition
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.util.Consumer
 import org.elm.lang.core.ElmFileType
+import java.util.function.Predicate
 
 @State(
     name = "ElmTestAutoTestManager",
@@ -20,11 +19,10 @@ class ElmTestAutoTestManager internal constructor(
 ) : AbstractAutoTestManager(project) {
 
     override fun createWatcher(project: Project) =
-        // This is the only constructor that is available both in Platform versions 2022.2.4 and master
         DelayedDocumentWatcher(project,
             myDelayMillis,
-            Consumer { value: Int -> restartAllAutoTests(value) },
-            Condition { it: VirtualFile -> it.fileType == ElmFileType && FileEditorManager.getInstance(project).isFileOpen(it) }
+            this::restartAllAutoTests,
+            Predicate { it: VirtualFile -> it.fileType == ElmFileType && FileEditorManager.getInstance(project).isFileOpen(it) }
         )
 }
 


### PR DESCRIPTION
As seen from the comment, the old constructor was used for compatibility with platform version 2022.2.4, but the plugin is now targeting platform version 2022.3, so we can switch to the non-deprecated constructor.

This fixes #8.