### PR TITLE
fix: show review and compiler toolwindow

### DIFF
--- a/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerToolWindowFactory.kt
+++ b/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerToolWindowFactory.kt
@@ -1,5 +1,7 @@
 package org.elm.ide.toolwindow
 
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.wm.ToolWindow
@@ -7,6 +9,7 @@ import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.content.impl.ContentImpl
 import com.intellij.util.ui.MessageCategory
 import org.elm.openapiext.findFileByPath
+import org.elm.workspace.compiler.ELM_BUILD_ACTION_ID
 import org.elm.workspace.compiler.ElmBuildAction
 import org.elm.workspace.compiler.ElmError
 import java.nio.file.Path
@@ -14,10 +17,16 @@ import java.nio.file.Path
 class ElmCompilerToolWindowFactory : ToolWindowFactory {
 
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val errorTreeViewPanel = object : ElmErrorTreeViewPanel(project, "Elm Compiler", createExitAction = false, createToolbar = true) {
+            override fun getRerunAction(): AnAction? = ActionManager.getInstance().getAction(ELM_BUILD_ACTION_ID)
+        }
+        toolWindow.contentManager.addContent(ContentImpl(errorTreeViewPanel, "Compilation Result", true))
+
+        
         with(project.messageBus.connect()) {
             subscribe(ElmBuildAction.ERRORS_TOPIC, object : ElmBuildAction.ElmErrorsListener {
                 override fun update(baseDirPath: Path, messages: List<ElmError>, targetPath: String, offset: Int) {
-                    val errorTreeViewPanel = ElmErrorTreeViewPanel(project, "Elm Compiler", createExitAction = false, createToolbar = true)
+                    errorTreeViewPanel.clearMessages()
 
                     messages.forEachIndexed { index, elmError ->
                         val sourceLocation = elmError.location
@@ -35,8 +44,7 @@ class ElmCompilerToolWindowFactory : ToolWindowFactory {
                         )
                     }
 
-                    toolWindow.contentManager.removeAllContents(true)
-                    toolWindow.contentManager.addContent(ContentImpl(errorTreeViewPanel, "Compilation Result", true))
+                    errorTreeViewPanel.reload()
                     toolWindow.show(null)
                     errorTreeViewPanel.expandAll()
                     errorTreeViewPanel.requestFocus()

--- a/src/main/kotlin/org/elm/ide/toolwindow/ElmErrorTreeViewPanel.kt
+++ b/src/main/kotlin/org/elm/ide/toolwindow/ElmErrorTreeViewPanel.kt
@@ -1,12 +1,17 @@
 package org.elm.ide.toolwindow
 
 import com.intellij.ide.errorTreeView.NewErrorTreeViewPanel
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindowManager
+import org.elm.workspace.compiler.ELM_BUILD_ACTION_ID
 import javax.swing.event.TreeSelectionListener
 
-class ElmErrorTreeViewPanel(project: Project, helpId: String?, createExitAction: Boolean, createToolbar: Boolean) :
+abstract class ElmErrorTreeViewPanel(project: Project, helpId: String?, createExitAction: Boolean, createToolbar: Boolean) :
     NewErrorTreeViewPanel(project, helpId, createExitAction, createToolbar) {
 
     val messages = mutableListOf<String>()
@@ -33,4 +38,20 @@ class ElmErrorTreeViewPanel(project: Project, helpId: String?, createExitAction:
             reportUI.text = ""
         }
     }
+
+    override fun fillRightToolbarGroup(group: DefaultActionGroup) {
+        val rerunAction = getRerunAction()
+        if (rerunAction != null) {
+            group.addSeparator()
+            group.add(rerunAction)
+        }
+    }
+
+    abstract fun getRerunAction(): AnAction?
+
+    fun clearMessages() {
+        errorViewStructure.clear()
+    }
+
+    override fun canHideWarnings(): Boolean = false
 }


### PR DESCRIPTION
The content of the tool windows for review and compile only were shown when there were actual errors or warnings triggered by running the plugins review action (Menu Code > Review Elm Project) or compile action (Menu Tools > Elm > Elm Compiler > Build Elm Project).

This PR changes the tool window to always show the contents and additionally adds a toolbar on the left side to (re-) run the action related to the tool window.