### PR TITLE
Fixed Internal API usage and modernize in places

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="project">
+    <words>
+      <w>lamdera</w>
+    </words>
+  </dictionary>
+</component>

--- a/README.md
+++ b/README.md
@@ -21,21 +21,19 @@ The original repo was [klazuka/intellij-elm](https://github.com/klazuka/intellij
 You may want to have some CLI tools --`elm` (the Elm compiler), [`elm-test`](docs/elm-test.md), [`elm-format`](docs/features/elm-format.md),
 [`elm-review`](docs/features/elm-review.md) and [`lamdera`](docs/features/lamdera.md)-- installed for certain features of this plugin to work.
 
-Install the first three with:
+You can install these globally with:
 
 ```bash
-sudo npm install -g elm elm-test elm-format elm-review
+sudo npm install -g elm elm-test elm-format elm-review lamdera
 ```
 
 **NOTE**: if you have [node](https://nodejs.org) installed using [nvm](https://github.com/nvm-sh/nvm), make sure to read [our NVM setup guide](docs/nvm.md).
-
-To install the Lamdera Elm compiler, follow [their instructions](https://lamdera.com/start).
 
 To install the plugin itself first make sure to uninstall all other Elm plugins you may have installed (this requires a restart of the IDE).
 Some have reported that having two Elm plugins installed results in the IDE not starting but showing a seemingly unrelated error
 (if you have this problem, there are [ways to fix it](https://intellij-support.jetbrains.com/hc/en-us/community/posts/360000524244-Disable-Uninstall-plugin-without-launching-Idea)).
 
-From within a JetBrains IDE, go to `Settings` -> `Plugins` -> `Marketplace` and search for "TODO name of new plugin" (not yet available on the JetBrains Marketplace).
+From within a JetBrains IDE, go to `Settings` -> `Plugins` -> `Marketplace` and search for "Elm Language". If you get multiple hits look for the most recently updated version, since there are still older versions of the plugin available.
 After installing the plugin, restart the IDE and then [open your existing Elm project](docs/existing-project.md) or [create a new project](docs/new-project.md).
 
 Alternatively you can install it manually by downloading a [release](https://github.com/elm-tooling/intellij-elm/releases) (or downloading the source and building it yourself) and

--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ The original repo was [klazuka/intellij-elm](https://github.com/klazuka/intellij
 
 ## Install
 
-> [!NOTE]
-> This elm-tooling/intellij-elm repo has not yet been released to the JetBrains Marketplace. The Elm plugin you’ll find over there is from the original [intellij-elm/intellij-elm](https://github.com/intellij-elm/intellij-elm) repo. See the [History](#history) section for more information. 
-
 You may want to have some CLI tools --`elm` (the Elm compiler), [`elm-test`](docs/elm-test.md), [`elm-format`](docs/features/elm-format.md),
 [`elm-review`](docs/features/elm-review.md) and [`lamdera`](docs/features/lamdera.md)-- installed for certain features of this plugin to work.
 
@@ -33,13 +30,14 @@ To install the plugin itself first make sure to uninstall all other Elm plugins 
 Some have reported that having two Elm plugins installed results in the IDE not starting but showing a seemingly unrelated error
 (if you have this problem, there are [ways to fix it](https://intellij-support.jetbrains.com/hc/en-us/community/posts/360000524244-Disable-Uninstall-plugin-without-launching-Idea)).
 
-From within a JetBrains IDE, go to `Settings` -> `Plugins` -> `Marketplace` and search for "Elm Language". If you get multiple hits look for the most recently updated version, since there are still older versions of the plugin available.
-After installing the plugin, restart the IDE and then [open your existing Elm project](docs/existing-project.md) or [create a new project](docs/new-project.md).
+From within a JetBrains IDE, go to `Settings` -> `Plugins` -> `Marketplace` and search for "Elm Language". If you get multiple hits look 
+for the most recently updated version, since there are still older versions of the plugin available. After installing the plugin, 
+restart the IDE and then [open your existing Elm project](docs/existing-project.md) or [create a new project](docs/new-project.md).
 
 Alternatively you can install it manually by downloading a [release](https://github.com/elm-tooling/intellij-elm/releases) (or downloading the source and building it yourself) and
 installing it with `Settings` -> `Plugins` -> `⚙️ (gear icon)` -> `Install plugin from disk...`
 
-Once the plugin is installed it is advised to double check all CLI tools are found by going to
+Once the plugin is installed it is advised to double-check all CLI tools are found by going to
 **Settings** -> **Languages & Frameworks** -> **Elm** and see the CLI tools. 
 
 

--- a/src/main/kotlin/org/elm/ide/actions/ElmExternalReviewWatchmodeAction.kt
+++ b/src/main/kotlin/org/elm/ide/actions/ElmExternalReviewWatchmodeAction.kt
@@ -9,16 +9,15 @@ import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.KeyWithDefaultValue
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import org.elm.ide.notifications.showBalloon
 import org.elm.lang.core.ElmFileType
 import org.elm.openapiext.saveAllDocuments
-import org.elm.workspace.*
 import org.elm.workspace.commandLineTools.makeProject
 import org.elm.workspace.compiler.findEntrypoints
-import java.util.*
+import org.elm.workspace.elmToolchain
+import org.elm.workspace.elmWorkspace
 
 private val log = logger<ElmExternalReviewAction>()
 

--- a/src/main/kotlin/org/elm/ide/hints/ElmParameterInfoHandler.kt
+++ b/src/main/kotlin/org/elm/ide/hints/ElmParameterInfoHandler.kt
@@ -1,7 +1,9 @@
 package org.elm.ide.hints
 
-import com.intellij.codeInsight.lookup.LookupElement
-import com.intellij.lang.parameterInfo.*
+import com.intellij.lang.parameterInfo.CreateParameterInfoContext
+import com.intellij.lang.parameterInfo.ParameterInfoHandler
+import com.intellij.lang.parameterInfo.ParameterInfoUIContext
+import com.intellij.lang.parameterInfo.UpdateParameterInfoContext
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement

--- a/src/main/kotlin/org/elm/ide/intentions/MakeEncoderIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/MakeEncoderIntention.kt
@@ -6,7 +6,7 @@ import org.elm.lang.core.psi.elements.ElmTypeDeclaration
 import org.elm.lang.core.types.*
 
 class MakeEncoderIntention : AnnotationBasedGeneratorIntention() {
-    override fun getText() = "Generate Encoder"
+    override fun getText() = "Generate encoder"
 
     override fun getRootIfApplicable(annotationTy: Ty): Ty? {
         if (annotationTy !is TyFunction) return null

--- a/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerToolWindowFactory.kt
+++ b/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerToolWindowFactory.kt
@@ -1,12 +1,12 @@
 package org.elm.ide.toolwindow
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.content.impl.ContentImpl
 import com.intellij.util.ui.MessageCategory
-import org.elm.openapiext.findFileByPath
 import org.elm.workspace.compiler.ElmBuildAction
 import org.elm.workspace.compiler.ElmError
 import java.nio.file.Path
@@ -22,25 +22,31 @@ class ElmCompilerToolWindowFactory : ToolWindowFactory {
                     messages.forEachIndexed { index, elmError ->
                         val sourceLocation = elmError.location
                         val virtualFile = sourceLocation?.let {
-                            baseDirPath.resolve(sourceLocation.path).let {
-                                LocalFileSystem.getInstance().findFileByPath(it)
-                            }                        }
+                            val fullPath = baseDirPath.resolve(it.path)
+                            LocalFileSystem.getInstance().refreshAndFindFileByPath(fullPath.toString())
+                        }
+
                         val encodedIndex = "\u200B".repeat(index)
                         errorTreeViewPanel.addMessage(
                             MessageCategory.ERROR, arrayOf("$encodedIndex${elmError.title}"),
                             virtualFile,
-                            sourceLocation?.region?.start?.let { it.line - 1 } ?: 0,
-                            sourceLocation?.region?.start?.let { it.column - 1 } ?: 0,
+                            sourceLocation?.region?.start?.line?.minus(1) ?: 0,
+                            sourceLocation?.region?.start?.column?.minus(1) ?: 0,
                             elmError.html
                         )
                     }
 
-                    toolWindow.contentManager.removeAllContents(true)
-                    toolWindow.contentManager.addContent(ContentImpl(errorTreeViewPanel, "Compilation Result", true))
-                    toolWindow.show(null)
-                    errorTreeViewPanel.expandAll()
-                    errorTreeViewPanel.requestFocus()
-                    focusEditor(project)
+                    // Ensure UI updates happen on the Event Dispatch Thread
+                    ApplicationManager.getApplication().invokeLater {
+                        toolWindow.contentManager.removeAllContents(true)
+                        toolWindow.contentManager.addContent(
+                            ContentImpl(errorTreeViewPanel, "Compilation Result", true)
+                        )
+                        toolWindow.show(null)
+                        errorTreeViewPanel.expandAll()
+                        errorTreeViewPanel.requestFocus()
+                        focusEditor(project)
+                    }
                 }
             })
         }

--- a/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerToolWindowFactory.kt
+++ b/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerToolWindowFactory.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.ui.content.impl.ContentImpl
 import com.intellij.util.ui.MessageCategory
 import org.elm.workspace.compiler.ElmBuildAction
@@ -37,7 +38,7 @@ class ElmCompilerToolWindowFactory : ToolWindowFactory {
                     }
 
                     // Ensure UI updates happen on the Event Dispatch Thread
-                    ApplicationManager.getApplication().invokeLater {
+                    ToolWindowManager.getInstance(project).invokeLater {
                         toolWindow.contentManager.removeAllContents(true)
                         toolWindow.contentManager.addContent(
                             ContentImpl(errorTreeViewPanel, "Compilation Result", true)

--- a/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerToolWindowFactory.kt
+++ b/src/main/kotlin/org/elm/ide/toolwindow/ElmCompilerToolWindowFactory.kt
@@ -1,6 +1,5 @@
 package org.elm.ide.toolwindow
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.wm.ToolWindow

--- a/src/main/kotlin/org/elm/ide/toolwindow/ElmWorkspacePanel.kt
+++ b/src/main/kotlin/org/elm/ide/toolwindow/ElmWorkspacePanel.kt
@@ -65,7 +65,7 @@ class ElmWorkspacePanel(private val project: Project) : SimpleToolWindowPanel(tr
 
 
     init {
-        setToolbar(createToolbar())
+        toolbar = createToolbar()
         setContent(ScrollPaneFactory.createScrollPane(projectListUI, 0))
 
         // populate the initial workspace state

--- a/src/main/kotlin/org/elm/ide/toolwindow/ElmWorkspacePanel.kt
+++ b/src/main/kotlin/org/elm/ide/toolwindow/ElmWorkspacePanel.kt
@@ -65,7 +65,7 @@ class ElmWorkspacePanel(private val project: Project) : SimpleToolWindowPanel(tr
 
 
     init {
-        toolbar = createToolbar()
+        setToolbar(createToolbar())
         setContent(ScrollPaneFactory.createScrollPane(projectListUI, 0))
 
         // populate the initial workspace state

--- a/src/main/kotlin/org/elm/lang/core/lexer/ElmLayoutLexer.kt
+++ b/src/main/kotlin/org/elm/lang/core/lexer/ElmLayoutLexer.kt
@@ -8,7 +8,6 @@ import com.intellij.psi.tree.TokenSet
 import com.intellij.util.text.CharArrayCharSequence
 import org.elm.lang.core.lexer.State.*
 import org.elm.lang.core.psi.ELM_COMMENTS
-import org.elm.lang.core.psi.ElmTypes
 import org.elm.lang.core.psi.ElmTypes.*
 import java.util.*
 

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -1038,7 +1038,7 @@ private class InferenceScope(
         }
         val assignable = try {
             assignable(ty1, ty2)
-        } catch (e: InfiniteTypeException) {
+        } catch (_: InfiniteTypeException) {
             diagnostics += InfiniteTypeError(element)
             return false
         }

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -1272,7 +1272,6 @@ private class InferenceScope(
             name2 == null -> unconstrainedAllowed
             name1 == name2 -> true
             name1 == "number" && name2 == "comparable" -> true
-            name1 == "comparable" && name2 == "number" -> true
             name1 == "comparable" && (name2 == "number" || name2 == "compappend") -> true
             name1 == "compappend" && (name2 == "comparable" || name2 == "appendable") -> true
             else -> false

--- a/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
+++ b/src/main/kotlin/org/elm/lang/core/types/TypeInference.kt
@@ -343,7 +343,9 @@ private class InferenceScope(
         fun validateTree(tree: BinaryExprTree<ElmBinOpPartTag>): TyAndRange {
             return when (tree) {
                 is BinaryExprTree.Operand -> {
-                    val ty = inferOperand(tree.operand as ElmOperandTag)
+                    val operandTag = tree.operand as? ElmOperandTag
+                        ?: error("Expected ElmOperandTag but got ${tree.operand::class.simpleName} at ${tree.operand.text}")
+                    val ty = inferOperand(operandTag)
                     TyAndRange(tree.operand, ty)
                 }
                 is BinaryExprTree.Binary -> {

--- a/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmToolchain.kt
@@ -100,7 +100,7 @@ data class ElmToolchain(
                 elmFormatPath = null,
                 elmTestPath = null,
                 elmReviewPath = null,
-                isElmFormatOnSaveEnabled = ElmToolchain.DEFAULT_FORMAT_ON_SAVE
+                isElmFormatOnSaveEnabled = DEFAULT_FORMAT_ON_SAVE
         )
 
         val MIN_SUPPORTED_COMPILER_VERSION = Version(0, 19, 0)


### PR DESCRIPTION
Another omnibus PR that tries to bring the plugin up to modern standards.

This PR fixes some warnings from the verification stage, but most importantly, fixes the one red error for Internal API usage in `Utils.kt`. 

The fix in `TypeInference.kt` addresses an error that was raised when testing the plugin in my own projects. 

Most of the other changes were done by following the suggestions of the IDE. 

