### PR TITLE
New: Add docs for a dedicated webpage

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,4 @@
+title: Elm Language Plugin for JetBrains IDEs
+description: Provides support for the [Elm programming language](https://elm-lang.org). This plugin is developed by the [Elm Tooling community](https://github.com/elm-tooling/intellij-elm/).
+logo: /assets/pluginIcon.svg
 theme: jekyll-theme-minimal

--- a/docs/assets/pluginIcon.svg
+++ b/docs/assets/pluginIcon.svg
@@ -1,0 +1,41 @@
+<svg:svg version="1.1" x="0" y="0" viewBox="0 0 323.141 322.95" xml:space="preserve" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svg="http://www.w3.org/2000/svg">
+    <svg:defs>
+        <svg:linearGradient id="b">
+            <svg:stop style="stop-color:#087cfa;stop-opacity:1" offset="0"/>
+            <svg:stop style="stop-color:#21d789;stop-opacity:1" offset="1"/>
+        </svg:linearGradient>
+        <svg:linearGradient id="d">
+            <svg:stop style="stop-color:#fc801d;stop-opacity:1" offset="0"/>
+            <svg:stop style="stop-color:#fe2857;stop-opacity:1" offset="1"/>
+        </svg:linearGradient>
+        <svg:linearGradient id="c">
+            <svg:stop style="stop-color:#21d789;stop-opacity:1" offset="0"/>
+            <svg:stop style="stop-color:#fcf84a;stop-opacity:1" offset="1"/>
+        </svg:linearGradient>
+        <svg:linearGradient id="e">
+            <svg:stop style="stop-color:#087cfa;stop-opacity:1" offset="0"/>
+            <svg:stop style="stop-color:#553eb4;stop-opacity:1" offset="1"/>
+        </svg:linearGradient>
+        <svg:linearGradient id="a">
+            <svg:stop style="stop-color:#553eb4;stop-opacity:1" offset="0"/>
+            <svg:stop style="stop-color:#ff318c;stop-opacity:1" offset="1"/>
+        </svg:linearGradient>
+        <svg:linearGradient xlink:href="#a" id="j" x1="45.966" y1="124.51" x2="120.686" y2="279.939" gradientUnits="userSpaceOnUse"/>
+        <svg:linearGradient xlink:href="#b" id="l" x1="229.02" y1="342.861" x2="156.727" y2="221.754" gradientUnits="userSpaceOnUse"/>
+        <svg:linearGradient xlink:href="#c" id="f" x1="201.55" y1="100.662" x2="162.23" y2="148.716" gradientUnits="userSpaceOnUse"/>
+        <svg:linearGradient xlink:href="#d" id="g" x1="154.947" y1="67.526" x2="108.468" y2="4.393" gradientUnits="userSpaceOnUse"/>
+        <svg:linearGradient xlink:href="#c" id="k" x1="312.305" y1="276.052" x2="277.906" y2="215.554" gradientUnits="userSpaceOnUse"/>
+        <svg:linearGradient xlink:href="#e" id="i" x1="322.66" y1="139.848" x2="292.069" y2="13.526" gradientUnits="userSpaceOnUse"/>
+        <svg:linearGradient xlink:href="#a" id="h" x1="335.55" y1="-13.529" x2="249.193" y2="-99.585" gradientUnits="userSpaceOnUse"/>
+    </svg:defs>
+    <svg:rect style="fill:#000;fill-opacity:1;stroke:none;stroke-width:0;stroke-dasharray:none" width="323.069" height="322.648" x=".197" y=".191"/>
+    <svg:g transform="matrix(.93036 0 0 .93036 11.258 11.258)">
+        <svg:polygon fill="#f0ad00" points="161.649,152.782 231.514,82.916 91.783,82.916" style="fill:url(#f);fill-opacity:1"/>
+        <svg:polygon fill="#7fd13b" points="161.838,0 8.867,0 79.241,70.375 232.213,70.375" style="fill:url(#g);fill-opacity:1"/>
+        <svg:rect fill="#7fd13b" x="234.873" y="-114.436" transform="rotate(45)" width="107.675" height="108.166" style="fill:url(#h);fill-opacity:1;stroke-width:.99999"/>
+        <svg:polygon fill="#60b5cc" points="323.298,143.724 323.298,0 179.573,0" style="fill:url(#i);fill-opacity:1"/>
+        <svg:polygon fill="#5a6378" points="152.781,161.649 0,8.868 0,314.432" style="fill:url(#j);fill-opacity:1"/>
+        <svg:polygon fill="#f0ad00" points="255.522,246.655 323.298,314.432 323.298,178.879" style="fill:url(#k);fill-opacity:1"/>
+        <svg:polygon fill="#60b5cc" points="161.649,170.517 8.869,323.298 314.43,323.298" style="fill:url(#l);fill-opacity:1"/>
+    </svg:g>
+</svg:svg>

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -55,7 +55,7 @@ There is a dropdown box labeled "Run tests using" and change it from "Gradle" to
 The only time when you would want to have Gradle run the tests is if you change the parser or lexer definition, in which case we would need Gradle to re-build the parser and lexer prior to running the tests.
 
 To run the tests the `elm`, `elm-format` and `elm-review` commands need to be on your `$PATH`.
-Lamdera also needs to be installed, but I managed to simply link `elm` to `lamdera`, like with:
+Lamdera also needs to be installed, but you can simply link `elm` to `lamdera`, e.g.,:
 
 ```bash
 sudo ln -s /usr/local/bin/elm /usr/local/bin/lamdera
@@ -71,4 +71,6 @@ https://docs.github.com/en/get-started/exploring-projects-on-github/contributing
 
 ## Questions
 
-Have a question? Try reaching out to us on [Elm Slack](https://elmlang.herokuapp.com/) or create a GitHub issue. 
+Have a question? Try reaching out to us on the [Incremental Elm Discord](https://incrementalelm.com/chat) (Specifically, the `#intellij-elm` channel): https://discord.com/channels/534524278847045633/727577900525682699.
+
+You can also open a [Discussion topic](https://github.com/elm-tooling/intellij-elm/discussions) on GitHub.

--- a/docs/features/live-error-checking.md
+++ b/docs/features/live-error-checking.md
@@ -11,7 +11,7 @@ This feature operates in the background as you type, and it results in increased
 
 This feature is enabled by default.
 
-The syntax error checker cannot be disabled, but you can turn off the type checker and and unresolved reference checker. Disable them by going to **IntelliJ Settings -> Editor -> Inspections -> Elm** and un-checking each inspection that you want to disable.
+The syntax error checker cannot be disabled, but you can turn off the type checker and unresolved reference checker. Disable them by going to **IntelliJ Settings -> Editor -> Inspections -> Elm** and un-checking each inspection that you want to disable.
 
 ## Demo
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,62 @@
-# Moved
+This plugin provides support for the [Elm programming language](https://elm-lang.org). This plugin is developed
+by the [Elm Tooling community](https://github.com/elm-tooling/intellij-elm/).
 
-This webpage has been replaced by the [intellij-elm project README](https://github.com/klazuka/intellij-elm). 
+## Using the plugin
+
+Once the plugin is installed it is advised to double-check all CLI tools are found by going to `Settings` -> `Languages & Frameworks` -> `Elm` and see the CLI tools.
+
+After installing the plugin, restart the IDE and then [open your existing Elm project](existing-project.md) or [create a new project](new-project.md).
+
+## Install
+
+You may want to have some CLI tools --`elm` (the Elm compiler), [`elm-test`](features/elm-test.md), [`elm-format`](features/elm-format.md),
+[`elm-review`](features/elm-review.md) and [`lamdera`](features/lamdera.md)-- installed for certain features of this plugin to work.
+
+You can install these globally with:
+
+```bash
+sudo npm install -g elm elm-test elm-format elm-review lamdera
+```
+
+**NOTE**: if you have [node](https://nodejs.org) installed using [nvm](https://github.com/nvm-sh/nvm), make sure to read [our NVM setup guide](nvm.md).
+
+To install the plugin itself first make sure to uninstall all other Elm plugins you may have installed (this requires a restart of the IDE).
+Some have reported that having two Elm plugins installed results in the IDE not starting but showing a seemingly unrelated error
+(if you have this problem, there are [ways to fix it](https://intellij-support.jetbrains.com/hc/en-us/community/posts/360000524244-Disable-Uninstall-plugin-without-launching-Idea)).
+
+From within a JetBrains IDE, go to `Settings` -> `Plugins` -> `Marketplace` and search for "Elm Language". If you get multiple hits look
+for the most recently updated version, since there are still older versions of the plugin available. Alternatively you can install it 
+manually by downloading a [release](https://github.com/elm-tooling/intellij-elm/releases) (or downloading the source and building it yourself) and installing it with 
+`Settings` -> `Plugins` -> `⚙️ (gear icon)` -> `Install plugin from disk...`
+
+## Features
+
+* [Live error checking](features/live-error-checking.md)
+* [Generate JSON encoder and decoder functions](features/generate-function-json.md)
+* [Rename refactoring](features/rename-refactoring.md)
+* [Lamdera support](features/lamdera.md)
+* [Support for `elm-review`](features/elm-review.md)
+* [Type inference and type checking](features/type-inference.md)
+* [Find usages](features/find-usages.md)
+* [Run tests](features/elm-test.md) (elm-test)
+* [Reformat code using `elm-format`](features/elm-format.md) (elm-format)
+* [Cleanup unused imports](features/unused-imports.md)
+* [Detect unused code](features/unused-code.md)
+* ['Add Import' quick fix for unresolved references](features/add-imports.md)
+* [Quick Docs](features/quick-docs.md)
+* [Structure view and quick navigation](features/structure-view.md)
+* [WebGL/GLSL support](features/webgl.md)
+* [Code folding](features/code-folding.md)
+* [Manage exposing lists](features/exposure.md)
+
+Want to see it in action? This [10 minute video](https://www.youtube.com/watch?v=CC2TdNuZztI) demonstrates many of the features and how they work together.
+
+## Contributing
+
+Yes, please! See [our guide](/docs/contributing.md) on this topic.
+
+## Development and Building
+
+
+
+


### PR DESCRIPTION
It's nice to have a dedicated webpage, and it's mostly there -- it just needed a few files fixed.

I've already added the configuration for the repo, so the page is already published here: https://elm-tooling.github.io/intellij-elm/

It just needs content.