### PR TITLE
Fix IDE crash on expose

### DIFF
--- a/src/main/kotlin/org/elm/ide/intentions/ElmAtCaretIntentionActionBase.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/ElmAtCaretIntentionActionBase.kt
@@ -41,6 +41,8 @@ abstract class ElmAtCaretIntentionActionBase<Ctx> : BaseElementAtCaretIntentionA
 
     abstract fun invoke(project: Project, editor: Editor, context: Ctx)
 
+    override fun startInWriteAction(): Boolean = true
+
     final override fun invoke(project: Project, editor: Editor, element: PsiElement) {
         val context = findApplicableContext(project, editor, element) ?: return
         checkWriteAccessAllowed()

--- a/src/main/kotlin/org/elm/openapiext/Utils.kt
+++ b/src/main/kotlin/org/elm/openapiext/Utils.kt
@@ -21,6 +21,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
+import com.intellij.codeInsight.intention.preview.IntentionPreviewUtils
 import org.jdom.Element
 import org.jdom.input.SAXBuilder
 import java.nio.file.Path
@@ -38,6 +39,9 @@ val Project.modules: Collection<Module>
 
 
 fun checkWriteAccessAllowed() {
+    // In preview we must not assert write access; the platform runs without it.
+    if (IntentionPreviewUtils.isIntentionPreviewActive()) return
+
     check(ApplicationManager.getApplication().isWriteAccessAllowed) {
         "Needs write action"
     }


### PR DESCRIPTION
This was added with the help of ChatGPT. I gave it the stack trace in #33 and it helped me track down the error. I have been running a build of this for a day, and it seems to have fixed the error.

Note that this is branched from the "Warning Fixes" branch (#35), since doing it off develop led to conflicts with changed files. So that branch should be merged to develop first, then the actual file changes from this PR will be shown. The only actual commit in this PR is: 

https://github.com/elm-tooling/intellij-elm/pull/36/commits/c90cefa7cf8129a2000e853252bd60c786af0c3b

Here are some excerpts from the conversation with ChatGPT:

---
You’re hitting a bug in the Elm IntelliJ plugin: the “Expose” intention is trying to write while IntelliJ is generating the preview (which runs on a read-only copy). Hence IllegalStateException: Needs write action.

... 

What’s going on: the Elm intention calls a helper that asserts write access even when IntelliJ is trying to build a preview on a non-physical copy. For previews, the platform runs your intention outside a write action by design; any “must be inside write action” assertions (or writes) must be bypassed or refactored for preview runs. 

Below is a concrete, minimal set of changes that will make the Expose intention preview-safe without losing safety when the action is really applied.

1) Stop asserting write access during preview

In your UtilsKt.checkWriteAccessAllowed (or wherever that assertion lives), guard it:

```
import com.intellij.codeInsight.intention.preview.IntentionPreviewUtils

fun checkWriteAccessAllowed() {
    if (IntentionPreviewUtils.isIntentionPreviewActive()) return
    com.intellij.openapi.application.ApplicationManager.getApplication().assertWriteAccessAllowed()
}
```

The SDK explicitly recommends removing write-thread assertions in preview, or guarding them with isIntentionPreviewActive().  (https://plugins.jetbrains.com/docs/intellij/code-intentions-preview.html#implementation)

2) Make the intention “preview friendly”

Inside org.elm.ide.intentions.exposure.ExposeIntention (and/or its base ElmAtCaretIntentionActionBase):
	•	Ensure the intention starts in write action when actually applied:

```
override fun startInWriteAction(): Boolean = true
```

The default preview pipeline will only call invoke() on a file copy if startInWriteAction() returns true and other safety checks pass. It will still run without a write action because the PSI is non-physical; your code must not demand one in preview. 

```