### PR TITLE
Fixed: Error on exposure

### DIFF
--- a/src/main/kotlin/org/elm/ide/intentions/exposure/ExposeIntention.kt
+++ b/src/main/kotlin/org/elm/ide/intentions/exposure/ExposeIntention.kt
@@ -20,6 +20,7 @@ open class ExposeIntention : ExposureIntentionBase<ExposeIntention.Context>() {
     override fun findApplicableContext(project: Project, editor: Editor, element: PsiElement): Context? {
         val exposingList = getExposingList(element) ?: return null
 
+        // check if the caret is on the identifier that names the exposable declaration
         val decl = element.parent as? ElmExposableTag ?: return null
         if (decl.nameIdentifier != element) return null
 
@@ -32,6 +33,10 @@ open class ExposeIntention : ExposureIntentionBase<ExposeIntention.Context>() {
         }
     }
 
+    /**
+     * Creates a [Context] based on the passed in parameters. Overriding subclasses can return null if they find that
+     * the passed in [decl] isn't valid for their particular intention.
+     */
     protected open fun createContext(decl: ElmExposableTag, exposingList: ElmExposingList): Context? =
         Context(decl.name, exposingList)
 


### PR DESCRIPTION
A further error on the "Expose" intention was raised. A conversation with ChatGPT led to another fix for the intention.

The core error seems to be that this intention is trying to write the file when displaying a preview of the change in the intention. I can confirm that this change no longer raises the error, and it now correctly shows a preview of the change.

I think this was a slightly different error than the previous one, but I will lump it in with the previous crash on expose ticket.

Refs #33