### PR TITLE
Fixed: Encoder intention documentation

### DIFF
--- a/src/main/resources/intentionDescriptions/MakeEncoderIntention/before.elm.template
+++ b/src/main/resources/intentionDescriptions/MakeEncoderIntention/before.elm.template
@@ -1,1 +1,8 @@
-<spot>encode</spot> : Int -> Encode.Value
+import Json.Encode as Encode
+
+type alias Person =
+    { name : String
+    , age : Int
+    }
+
+<spot>personEncoder</spot> : Person -> Encode.Value


### PR DESCRIPTION
The "before" documentation for generating an encoder was not correct. This fixes it to match the "after".