### PR TITLE
Fixed: allow the plugin to run with EAP (and later)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,8 @@ pluginVersion = 5.2.0-alpha
 # See: https://intellij-support.jetbrains.com/hc/en-us/community/posts/360010590059-Why-pluginUntilBuild-is-mandatory
 pluginSinceBuild = 242
 # We do not set until build, as we want it to be compatible with new versions. See `plugin.xml`.
-pluginUntilBuild = 252.*
+# pluginUntilBuild = 252.*
+pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 # 2022.3 and newer require JDK17


### PR DESCRIPTION
This PR removes the restriction on the latest version of intellij that can run the plugin.

We should monitor this carefully to make sure newer versions still work with the plugin.

fixes #43