### PR TITLE
Don't zip release artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,11 +91,12 @@ jobs:
 
       # Store plugin ZIP for release draft asset upload
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.artifact.outputs.filename }}
           path: ${{ steps.artifact.outputs.path }}
           if-no-files-found: error
+          archive: false
 
 
   # Run tests and upload a code coverage report


### PR DESCRIPTION
The newest version of the `actions/upload-artifact` action allows uploading single files that don't get zipped.