### PR TITLE
Fixed: Explicit import of type shadowing wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Changelog for et-intellij-elm
 
 ## [Unreleased]
+*   Fixed: an explicitly imported type now shadows one brought in by a wildcard (`exposing (..)`) import, regardless of import order, matching how values already resolved
 
 ## [6.0.0] - 2026-04-13
 *   Fixed: Reworked the elm-review panel (#19)

--- a/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
+++ b/src/main/kotlin/org/elm/lang/core/resolve/scope/ModuleScope.kt
@@ -125,7 +125,7 @@ object ModuleScope {
                     ?.let { importDecl ->
                         when {
                             getVisibleImportValues(importDecl).any { it.element.name == name } -> ""
-                            getVisibleImportTypes(importDecl).any { it.name == name } -> ""
+                            getVisibleImportTypes(importDecl).any { it.element.name == name } -> ""
                             getVisibleImportConstructors(importDecl).any { it.name == name } -> ""
                             importDecl.asClause != null -> importDecl.asClause!!.name + "."
                             else -> importDecl.moduleQID.text + "."
@@ -280,21 +280,24 @@ object ModuleScope {
         return CachedValuesManager.getCachedValue(elmFile, VISIBLE_TYPES_KEY) {
             val fromGlobal = GlobalScope.forElmFile(elmFile)?.getVisibleTypes() ?: emptyList()
             val fromTopLevel = getDeclaredTypes(elmFile).list
+            // Explicit imports shadow names from wildcard imports, so we need to sort the names
             val fromImports = elmFile.getImportClauses()
                     .flatMap { getVisibleImportTypes(it) }
+                    .sortedBy { it.fromWildcard }
+                    .map { it.element }
             val names = VisibleNames(global = fromGlobal, topLevel = fromTopLevel, imported = fromImports)
             Result.create(names, elmFile.globalModificationTracker)
         }
     }
 
 
-    private fun getVisibleImportTypes(importClause: ElmImportClause): List<ElmNamedElement> {
+    private fun getVisibleImportTypes(importClause: ElmImportClause): List<ExposedElement> {
         val allExposedTypes = ImportScope.fromImportDecl(importClause)
                 ?.getExposedTypes()?.elements
                 ?: return emptyList()
 
         if (importClause.exposesAll)
-            return allExposedTypes.asList()
+            return allExposedTypes.map { ExposedElement(true, it) }
 
         // intersect the names exposed by the module with the names declared
         // in this import clause's exposing list.
@@ -302,6 +305,7 @@ object ModuleScope {
                 ?.mapTo(mutableSetOf()) { it.referenceName }
                 ?: return emptyList()
         return allExposedTypes.filter { locallyExposedNames.contains(it.name) }
+                .map { ExposedElement(false, it) }
     }
 
 

--- a/src/test/kotlin/org/elm/lang/core/resolve/ElmWildcardImportResolveTest.kt
+++ b/src/test/kotlin/org/elm/lang/core/resolve/ElmWildcardImportResolveTest.kt
@@ -40,4 +40,45 @@ bar = 42
 module Bar exposing (..)
 bar = 99
 """)
+
+    // https://github.com/elm/compiler/issues/2277
+    // A type exposed explicitly must shadow one brought in by a wildcard import,
+    // regardless of the order in which the imports are declared.
+    @Test
+    fun `test explicit type import shadowing wildcard`() = stubOnlyResolve(
+            """
+--@ main.elm
+import Foo exposing (..)
+import Bar exposing (Thing)
+type alias Wrapper = Thing
+                     --^Bar.elm
+
+--@ Foo.elm
+module Foo exposing (..)
+type Thing = Thing
+
+--@ Bar.elm
+module Bar exposing (..)
+type Thing = Thing
+""")
+
+    // Same as above, but with the explicit import first, to prove that the
+    // explicit import wins regardless of the order in which they are declared.
+    @Test
+    fun `test explicit type import shadowing wildcard 2`() = stubOnlyResolve(
+            """
+--@ main.elm
+import Foo exposing (Thing)
+import Bar exposing (..)
+type alias Wrapper = Thing
+                     --^Foo.elm
+
+--@ Foo.elm
+module Foo exposing (..)
+type Thing = Thing
+
+--@ Bar.elm
+module Bar exposing (..)
+type Thing = Thing
+""")
 }


### PR DESCRIPTION
The below is an error according to intellij-elm (`A.T` vs `B.T`), but not according to the Elm compiler:

```elm
module Main exposing (main)

import A exposing (..)
import B exposing (T)
import Html


data : ( String, T )
data =
    ( "test", B.B )


main =
    Html.text (Tuple.first data)
```

```elm
module A exposing (T(..))


type T
    = A
```

```elm
module B exposing (T(..))


type T
    = B
```

This PR fixes this issue.

This wildcard shadowing was already handled for values, but not for types. Now it’s handled for types, too, following the pattern used for values.

Note: This makes the explicitly exposed type win always. In reality, the Elm compiler gives an `AMBIGUOUS NAME` error if the wildcard comes _after_ the explicit exposing (see https://github.com/elm/compiler/issues/2277). Since the plugin does not have `AMBIGUOUS NAME` checking currently, I think it’s better to leave it like this – it would be a separate effort adding such checks.

_Note: I used Claude Code to create this PR._