### PR TITLE
Don’t mark the constructor of a phantom type as unused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Changelog for et-intellij-elm
 
 ## [Unreleased]
+*   The constructor of a phantom type (which is unused on purpose; must be marked with `Never` or the type itself) is no longer marked as unused
 
 ## [6.0.0] - 2026-04-13
 *   Fixed: Reworked the elm-review panel (#19)

--- a/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
+++ b/src/main/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspection.kt
@@ -37,6 +37,7 @@ class ElmUnusedSymbolInspection : ElmLocalInspection() {
 
         if (isProgramEntryPoint(element)) return
         if (isPackagePublicApi(element)) return
+        if (isPhantomTypeConstructor(element)) return
 
         if (scope is GlobalSearchScope) {
             // to keep inspection/analysis time brief, bail out if 'Find Usages' will be slow
@@ -81,6 +82,38 @@ class ElmUnusedSymbolInspection : ElmLocalInspection() {
                 *fixes
         )
     }
+}
+
+/**
+ * Detects two common ways of defining a phantom type, where the sole constructor is
+ * deliberately impossible to construct and is therefore never expected to be used:
+ *
+ * ```
+ * type MyType = Thing Never
+ * type MyOtherType = Foo MyOtherType
+ * ```
+ *
+ * The pattern is a type with exactly one constructor, taking exactly one argument, where the
+ * argument is either `Never` (from `Basics`) or the type itself.
+ *
+ * The pattern comes from elm-review-unused:
+ * https://github.com/jfmengels/elm-review-unused/blob/0ae615f97a56cd1218189bb34b7d41a95a0d952d/src/NoUnused/CustomTypeConstructors.elm#L621-L657
+ */
+private fun isPhantomTypeConstructor(element: ElmNameIdentifierOwner): Boolean {
+    val variant = element as? ElmUnionVariant ?: return false
+    val typeDeclaration = variant.parentOfType<ElmTypeDeclaration>() ?: return false
+
+    // must be the only constructor, taking a single argument that is a plain type reference
+    if (typeDeclaration.unionVariantList.size != 1) return false
+    val parameter = variant.allParameters.singleOrNull() as? ElmTypeRef ?: return false
+    if (parameter.allArguments.isNotEmpty()) return false
+
+    // the argument must be either the type itself or `Never` (as defined in `Basics`)
+    val resolved = parameter.reference.resolve() ?: return false
+    if (element.manager.areElementsEquivalent(resolved, typeDeclaration)) return true
+    return resolved is ElmTypeDeclaration
+            && resolved.name == "Never"
+            && resolved.elmFile.getModuleDecl()?.name == "Basics"
 }
 
 private fun isPackagePublicApi(element: ElmNameIdentifierOwner): Boolean {

--- a/src/test/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspectionTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmUnusedSymbolInspectionTest.kt
@@ -199,6 +199,44 @@ class ElmUnusedSymbolInspectionTest : ElmInspectionsTestBase(ElmUnusedSymbolInsp
         """.trimIndent())
 
     @Test
+    fun `test phantom type constructor taking Never is never marked as unused`() = checkByFileTree("""
+        --@ main.elm
+        import Basics exposing (Never)
+        type Id = Id Never
+        --^
+
+        --@ Basics.elm
+        module Basics exposing (Never)
+        type Never = JustOneMore Never
+        """.trimIndent())
+
+
+    @Test
+    fun `test phantom type constructor taking the type itself is never marked as unused`() = checkByText("""
+        type Id = Id Id
+        """.trimIndent())
+
+
+    @Test
+    fun `test a single unused constructor with an argument that is not phantom is still unused`() = checkByText("""
+        type Id = <warning descr="'Id' is never used">Id</warning> Int
+        """.trimIndent())
+
+
+    @Test
+    fun `test an unused constructor taking a same-named type from elsewhere is still unused`() = checkByFileTree("""
+        --@ main.elm
+        import Other exposing (Never)
+        type Id = <warning descr="'Id' is never used">Id</warning> Never
+        --^
+
+        --@ Other.elm
+        module Other exposing (Never)
+        type Never = Never
+        """.trimIndent())
+
+
+    @Test
     fun `test renames unused case branch patterns`() = checkFixByText("Rename to _", """
         type T = T () ()
         main : T -> ()


### PR DESCRIPTION
Small quality of life fix – fewer unfixable warnings. See the code comment and the test cases.

_Note: I used Claude Code to create this PR._