### PR TITLE
Fixed: Workaround Elm 0.19.2 off-by-one error locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 *   Fixed: an explicitly imported type now shadows one brought in by a wildcard (`exposing (..)`) import, regardless of import order, matching how values already resolved
 *   The constructor of a phantom type (which is unused on purpose; must be marked with `Never` or the type itself) is no longer marked as unused
+*   Fixed: Elm 0.19.2 has a bug where error locations are off-by-one – added a workaround for that in the Elm Compiler feature
 
 ## [6.0.0] - 2026-04-13
 *   Fixed: Reworked the elm-review panel (#19)

--- a/src/main/kotlin/org/elm/workspace/commandLineTools/ElmCLI.kt
+++ b/src/main/kotlin/org/elm/workspace/commandLineTools/ElmCLI.kt
@@ -36,6 +36,13 @@ class ElmCLI(val elmExecutablePath: Path) {
         try {
             val allMessages = mutableListOf<ElmError>()
             var allSucceeded = true
+            // Elm 0.19.2 has a bug where the error locations reported by `--report=json` are
+            // off by one: https://github.com/elm/compiler/issues/2358
+            // Correct them by adding 1 to each reported row and column. Computed
+            // lazily so we only run `elm --version` when there is actually an error to adjust.
+            val rowAndColumnOffset by lazy {
+                if (queryVersion(project).orNull()?.xyz == Version(0, 19, 2)) 1 else 0
+            }
             for (entry in entryPoints) {
                 val modeFlag = entry.mode.asFlag()
                 val params = mutableListOf("make")
@@ -64,7 +71,7 @@ class ElmCLI(val elmExecutablePath: Path) {
                 val regex = "\\{.*}".toRegex()
                 val cleansedJson = regex.find(json)?.value
                 if (!cleansedJson.isNullOrEmpty()) {
-                    allMessages += elmJsonToCompilerMessages(cleansedJson)
+                    allMessages += elmJsonToCompilerMessages(cleansedJson, rowAndColumnOffset)
                 }
             }
 

--- a/src/main/kotlin/org/elm/workspace/compiler/ElmJsonReport.kt
+++ b/src/main/kotlin/org/elm/workspace/compiler/ElmJsonReport.kt
@@ -6,7 +6,7 @@ import com.google.gson.Gson
 private val urlPattern = Regex("""<((http|https)://.*?)>""")
 
 
-fun elmJsonToCompilerMessages(json: String): List<ElmError> {
+fun elmJsonToCompilerMessages(json: String, rowAndColumnOffset: Int = 0): List<ElmError> {
     val report = Gson().fromJson(json, Report::class.java) ?: error("failed to parse JSON report from elm")
     return when (report) {
         is Report.General -> {
@@ -25,13 +25,20 @@ fun elmJsonToCompilerMessages(json: String): List<ElmError> {
                             location = ElmLocation(
                                     path = error.path,
                                     moduleName = error.name,
-                                    region = problem.region)
+                                    region = problem.region.offsetBy(rowAndColumnOffset))
                     )
                 }
             }
         }
     }
 }
+
+private fun Region.offsetBy(delta: Int): Region =
+        if (delta == 0) this
+        else Region(
+                start = Start(start.line + delta, start.column + delta),
+                end = End(end.line + delta, end.column + delta)
+        )
 
 private fun chunksToHtml(chunks: List<Chunk>): String =
         chunks.joinToString("",


### PR DESCRIPTION
Elm 0.19.2 has a bug where the error locations are off-by-one: https://github.com/elm/compiler/issues/2358

This means that when running the Elm compiler and double-clicking an error, you are taken to the line before where the error actually is.

This adds a workaround for 0.19.2, similar to:

- https://github.com/elm-land/vscode/pull/23
- https://github.com/lydell/elm-watch/pull/127
- https://github.com/lue-bird/elm-language-server-rs/issues/1

_Note: This PR was made using Claude Code._