### PR TITLE
Make tests work with both Elm 0.19.1 and 0.19.2

### DIFF
--- a/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmWorkspaceService.kt
@@ -366,7 +366,7 @@ class ElmWorkspaceService(private val intellijProject: Project) : PersistentStat
                 ?: resolveCompilerVersionForProjectLoad()
 
             if (installDeps) {
-                installProjectDeps(manifestPath)
+                installProjectDeps(manifestPath, elmCompilerVersion)
             }
 
             // not thread-safe; do not reuse across threads!
@@ -392,7 +392,7 @@ class ElmWorkspaceService(private val intellijProject: Project) : PersistentStat
             }
         }
 
-    private fun installProjectDeps(manifestPath: Path): Boolean {
+    private fun installProjectDeps(manifestPath: Path, compilerVersion: Version): Boolean {
         // The only way to install an Elm project's dependencies is to compile
         // the project. But the project may not be in a compilable state when
         // we try to load it. So we will copy the `elm.json` into a temp dir
@@ -406,6 +406,16 @@ class ElmWorkspaceService(private val intellijProject: Project) : PersistentStat
         val dto = mapper.readTree(manifestPath.toFile()) as ObjectNode
         if (dto.has("source-directories")) {
             dto.putArray("source-directories").add("src")
+        }
+
+        // An application's `elm.json` pins an exact `elm-version`, and the Elm compiler refuses
+        // to build (and therefore to download dependencies) unless it matches the compiler exactly.
+        // Since this is a throwaway copy used only to trigger the download, rewrite it to the
+        // compiler's own version so deps land in `~/.elm/<compilerVersion>/packages/` regardless of
+        // which 0.19.x the user has installed. (Packages declare a version *range*, so they never
+        // hit this mismatch and are left untouched. Lamdera has its own versioning scheme.)
+        if (settings.toolchain.compilerType == ElmCompilerType.ELM && dto.get("type")?.textValue() == "application") {
+            dto.put("elm-version", compilerVersion.toString())
         }
         val tempManifest = dir.toPath().resolve(ELM_JSON).toFile()
         mapper.writeValue(tempManifest, dto)
@@ -489,15 +499,11 @@ class ElmWorkspaceService(private val intellijProject: Project) : PersistentStat
             )
         } else
         runAsyncTask(intellijProject, "Preparing Elm project refresh") {
-            if (isUnitTestMode) {
-                Version(0, 19, 1)
-            } else {
-                settings.toolchain.queryCompilerVersion(intellijProject).orNull()
-                    ?: run {
-                        log.warn("Could not determine version of the selected compiler while refreshing Elm projects. Falling back to 0.19.1.")
-                        Version(0, 19, 1)
-                    }
-            }
+            settings.toolchain.queryCompilerVersion(intellijProject).orNull()
+                ?: run {
+                    log.warn("Could not determine version of the selected compiler while refreshing Elm projects. Falling back to 0.19.1.")
+                    Version(0, 19, 1)
+                }
         }.thenCompose { elmCompilerVersion ->
             allProjects.map { elmProject ->
                 asyncLoadProject(
@@ -569,7 +575,6 @@ class ElmWorkspaceService(private val intellijProject: Project) : PersistentStat
     }
 
     private fun resolveCompilerVersionForProjectLoad(): Version {
-        if (isUnitTestMode) return Version(0, 19, 1)
         return settings.toolchain.queryCompilerVersion(intellijProject).orNull()
             ?: run {
                 log.warn("Could not determine version of the selected compiler while loading Elm projects. Falling back to 0.19.1.")

--- a/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
+++ b/src/test/kotlin/org/elm/workspace/ElmWorkspaceTestBase.kt
@@ -30,6 +30,15 @@ abstract class ElmWorkspaceTestBase : CodeInsightFixtureTestCase<ModuleFixtureBu
     protected val elmWorkspaceDirectory: VirtualFile
         get() = myFixture.findFileInTempDir(".")
 
+    /**
+     * The version of the Elm compiler the developer has installed (e.g. 0.19.1, 0.19.2, ...).
+     * Test fixtures that are compiled by the real compiler must declare this version in their
+     * `elm.json`, otherwise the compiler rejects them with an "ELM VERSION MISMATCH" error.
+     * Falls back to 0.19.1 if the compiler version cannot be determined.
+     */
+    protected val installedElmCompilerVersion: Version
+        get() = toolchain.queryCompilerVersion(project).orNull() ?: Version(0, 19, 1)
+
     protected fun awaitWorkspaceLoaded(retries: Int = 3, timeoutSeconds: Long = 30): Boolean {
         repeat(retries) {
             project.elmWorkspace.asyncDiscoverAndRefresh().get(timeoutSeconds, TimeUnit.SECONDS)

--- a/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
+++ b/src/test/kotlin/org/elm/workspace/StdlibInstallHelper.kt
@@ -66,15 +66,17 @@ object EmptyElmStdlibVariant : ElmStdlibVariant {
  * required to compile an Elm application.
  */
 object MinimalElmStdlibVariant : ElmStdlibVariant {
-    override val jsonManifest: String
-        @Language("JSON")
-        get() = """
+    // The Elm compiler refuses to compile an application whose `elm.json` declares a different
+    // `elm-version` than the compiler itself. Parameterize the version so this manifest matches
+    // whichever 0.19.x compiler the developer happens to have installed (0.19.1, 0.19.2, ...).
+    @Language("JSON")
+    fun manifestFor(elmVersion: Version): String = """
             {
                 "type": "application",
                 "source-directories": [
                     "."
                 ],
-                "elm-version": "0.19.1",
+                "elm-version": "$elmVersion",
                 "dependencies": {
                     "direct": {
                         "elm/core": "1.0.0",
@@ -88,6 +90,9 @@ object MinimalElmStdlibVariant : ElmStdlibVariant {
                 }
             }
             """.trimIndent()
+
+    override val jsonManifest: String
+        get() = manifestFor(Version(0, 19, 1))
 
     override fun ensureElmStdlibInstalled(project: Project, toolchain: ElmToolchain) {
         val elmCLI = toolchain.elmCLI
@@ -103,7 +108,7 @@ object MinimalElmStdlibVariant : ElmStdlibVariant {
                 ?: error("Could not create on-disk temp dir for Elm stdlib installation")
 
         fileTree {
-            project(ELM_JSON, jsonManifest)
+            project(ELM_JSON, manifestFor(compilerVersion))
             elm("Main.elm")
         }.create(project, onDiskTmpDir)
 

--- a/src/test/kotlin/org/elm/workspace/compiler/ElmBuildActionTest.kt
+++ b/src/test/kotlin/org/elm/workspace/compiler/ElmBuildActionTest.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.TestActionEvent
 import junit.framework.TestCase
 import org.elm.workspace.ElmWorkspaceTestBase
+import org.elm.workspace.Version
 import org.elm.workspace.elmToolchain
 import org.elm.workspace.elmWorkspace
 import org.intellij.lang.annotations.Language
@@ -29,7 +30,7 @@ class ElmBuildActionTest : ElmWorkspaceTestBase() {
                 """.trimIndent()
 
         buildProject {
-            project("elm.json", manifestElm19)
+            project("elm.json", manifestElm19(installedElmCompilerVersion))
             dir("src") {
                 elm("Main.elm", source)
             }
@@ -74,7 +75,7 @@ class ElmBuildActionTest : ElmWorkspaceTestBase() {
                 """.trimIndent()
 
         buildProject {
-            project("elm.json", manifestElm19)
+            project("elm.json", manifestElm19(installedElmCompilerVersion))
             dir("src") {
                 elm("Main.elm", source)
             }
@@ -98,7 +99,7 @@ class ElmBuildActionTest : ElmWorkspaceTestBase() {
                 """.trimIndent()
 
         buildProject {
-            project("elm.json", manifestElm19)
+            project("elm.json", manifestElm19(installedElmCompilerVersion))
             dir("src") {
                 elm("Foo.elm", source)
             }
@@ -211,14 +212,17 @@ class ElmBuildActionTest : ElmWorkspaceTestBase() {
     }
 }
 
+// The Elm compiler refuses to compile an application whose `elm.json` declares a different
+// `elm-version` than the compiler itself, so this manifest is parameterized by the installed
+// compiler version (0.19.1, 0.19.2, ...) rather than hardcoding one.
 @Language("JSON")
-private val manifestElm19 = """
+private fun manifestElm19(elmVersion: Version) = """
         {
             "type": "application",
             "source-directories": [
                 "src"
             ],
-            "elm-version": "0.19.1",
+            "elm-version": "$elmVersion",
             "dependencies": {
                 "direct": {
                     "elm/core": "1.0.0",


### PR DESCRIPTION
This makes the tests pass even if you have Elm 0.19.2 installed globally.

_Note: I made this PR with Claude Code._