### PR TITLE
Don’t use deprecated API:s

### DIFF
--- a/src/main/kotlin/org/elm/ide/annotator/ElmReviewPass.kt
+++ b/src/main/kotlin/org/elm/ide/annotator/ElmReviewPass.kt
@@ -6,11 +6,11 @@ import com.intellij.codeHighlighting.TextEditorHighlightingPassRegistrar
 import com.intellij.codeInsight.daemon.impl.DaemonCodeAnalyzerEx
 import com.intellij.codeInsight.daemon.impl.FileStatusMap
 import com.intellij.codeInsight.daemon.impl.HighlightInfo
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.application.ReadAction
-import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
@@ -83,10 +83,10 @@ class ElmReviewPass(
     }
 
     private fun doFinish(groupedHighlights: List<HighlightInfo>) {
-        invokeLater(ModalityState.stateForComponent(editor.component)) {
+        ApplicationManager.getApplication().invokeLater({
             applyHighlighters(groupedHighlights)
             DaemonCodeAnalyzerEx.getInstanceEx(myProject).fileStatusMap.markFileUpToDate(document, id)
-        }
+        }, ModalityState.stateForComponent(editor.component))
     }
 
     private fun applyHighlighters(groupedHighlights: List<HighlightInfo>) {

--- a/src/main/kotlin/org/elm/ide/annotator/ElmReviewPass.kt
+++ b/src/main/kotlin/org/elm/ide/annotator/ElmReviewPass.kt
@@ -9,9 +9,10 @@ import com.intellij.codeInsight.daemon.impl.HighlightInfo
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.application.invokeLater
-import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.project.DumbAware
@@ -46,7 +47,7 @@ class ElmReviewPass(
         val pathToListenFor: Path = elmProject.projectDirPath
 
         val service = editor.project?.elmReviewService ?: return
-        val sourceFilePath = runReadAction { Path.of(file.virtualFile.path) }
+        val sourceFilePath = ReadAction.compute<Path, Throwable> { Path.of(file.virtualFile.path) }
         service.runReviewOnDocumentChange(
             projectBasePath = pathToListenFor,
             sourceFilePath = sourceFilePath,
@@ -66,7 +67,7 @@ class ElmReviewPass(
             doFinish(emptyList())
             return
         }
-        runReadAction {
+        ReadAction.run<Throwable> {
             doFinish(collectCurrentFileHighlights())
         }
     }
@@ -175,7 +176,7 @@ class ElmReviewPassFactory(
                     scheduleExternalActivity(object : Update(baseDirPath) {
                         override fun run() {
                             val daemon = DaemonCodeAnalyzerEx.getInstanceEx(project)
-                            val docsToMark = runReadAction {
+                            val docsToMark = ReadAction.compute<List<Document>, Throwable> {
                                 val psiManager = PsiManager.getInstance(project)
                                 FileEditorManager.getInstance(project).openFiles
                                     .mapNotNull { psiManager.findFile(it) as? ElmFile }

--- a/src/main/kotlin/org/elm/openapiext/Subprocesses.kt
+++ b/src/main/kotlin/org/elm/openapiext/Subprocesses.kt
@@ -31,7 +31,7 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
 import com.intellij.execution.process.ProcessOutput
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.util.io.systemIndependentPath
@@ -72,7 +72,7 @@ fun GeneralCommandLine.execute(
             CapturingProcessHandler(this)
         }
 
-    val alreadyDisposed = runReadAction { project.isDisposed }
+    val alreadyDisposed = ReadAction.compute<Boolean, Throwable> { project.isDisposed }
     if (alreadyDisposed) {
         return ProcessOutput().apply { setCancelled() }
     }

--- a/src/main/kotlin/org/elm/workspace/commandLineTools/ElmReviewCLI.kt
+++ b/src/main/kotlin/org/elm/workspace/commandLineTools/ElmReviewCLI.kt
@@ -6,7 +6,7 @@ import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.runBackgroundableTask
@@ -55,7 +55,7 @@ class ElmReviewCLI(private val elmReviewExecutablePath: Path) {
                 val handler = CapturingProcessHandler(generalCommandLine)
                 try {
                     val output = handler.runProcess()
-                    val alreadyDisposed = runReadAction { project.isDisposed }
+                    val alreadyDisposed = ReadAction.compute<Boolean, Throwable> { project.isDisposed }
                     if (alreadyDisposed) {
                         throw ExecutionException("External command failed to start")
                     }

--- a/src/test/kotlin/org/elm/ide/inspections/ElmReviewUtilsTest.kt
+++ b/src/test/kotlin/org/elm/ide/inspections/ElmReviewUtilsTest.kt
@@ -1,6 +1,8 @@
 package org.elm.ide.inspections
 
-import com.intellij.openapi.application.runReadAction
+import com.intellij.codeInsight.daemon.impl.HighlightInfo
+import com.intellij.openapi.application.ReadAction
+import com.intellij.psi.PsiFile
 import junit.framework.TestCase
 import org.elm.workspace.ElmWorkspaceTestBase
 import org.elm.workspace.elmWorkspace
@@ -33,7 +35,7 @@ class ElmReviewUtilsTest : ElmWorkspaceTestBase() {
         )
         val result = ElmReviewResult(listOf(message), basePath, 0)
 
-        val highlights = runReadAction { highlightsForFile(project, basePath, result) }
+        val highlights = ReadAction.compute<List<Pair<PsiFile, HighlightInfo>>, Throwable> { highlightsForFile(project, basePath, result) }
 
         TestCase.assertEquals(1, highlights.size)
         TestCase.assertEquals(file.path, highlights[0].first.virtualFile.path)
@@ -60,7 +62,7 @@ class ElmReviewUtilsTest : ElmWorkspaceTestBase() {
         )
         val result = ElmReviewResult(listOf(message), basePath, 0)
 
-        val highlights = runReadAction { highlightsForFile(project, basePath, result) }
+        val highlights = ReadAction.compute<List<Pair<PsiFile, HighlightInfo>>, Throwable> { highlightsForFile(project, basePath, result) }
 
         assertTrue(highlights.isEmpty())
     }


### PR DESCRIPTION
The plugin page shows these deprecated API usages (when logged in):

- ActionsKt.runReadAction(Function0) (5)
- FileStatusMap.markFileUpToDate(Document, int) (1)

I asked Claude to fix the first one. It looked fairly straightforward. Note: The API:s we are switching to _becomes_ deprecated in the latest platform (which we do not use yet): https://plugins.jetbrains.com/docs/intellij/api-notable-list-2026.html. Claude says this PR still helps preparing for the upgrade to the platform in the future. I also found https://plugins.jetbrains.com/docs/intellij/threading-model.html#read-actions-api which says: “Plugins implemented in Kotlin and targeting versions 2024.1+ should use suspending [readAction()](https://github.com/JetBrains/intellij-community/tree/idea/262.8665.258/platform/core-api/src/com/intellij/openapi/application/coroutines.kt). See also [Coroutine Read Actions](https://plugins.jetbrains.com/docs/intellij/coroutine-read-actions.html).” Claude says that only applies if using coroutines – which Claude says we aren’t here.

While Claude fixed those, Claude also noticed a deprecated `invokeLater` call, which I told Claude to fix as well while at it.

For the second one, Claude recommended we don’t do anything for now. <details><summary>Motivation</summary>

This one is different from the previous two, and I'd recommend not changing it. Here's why:

The deprecation isn't real for the version you build against. In platformVersion = 2024.3.6 (the only SDK cached, and what the compiler + editor resolve against), markFileUpToDate(Document, int) is not deprecated and is the only overload that exists. The warning you're seeing comes from the newer platform (the 2025.3.3 you run plugin-verification against), where upstream deprecated it.

The replacement can't be used against 2024.3.6. Upstream's suggested replacement is:

@ApiStatus.Experimental
public void markFileUpToDate(Document document, CodeInsightContext context, int passId, ProgressIndicator indicator)

▎ deprecation message: "use #markFileUpToDate(Document, CodeInsightContext, int, ProgressIndicator) instead"

I checked the 2024.3.6 SDK directly:
- CodeInsightContext — not present in any jar
- the 4-arg overload — doesn't exist

So switching to it would break compilation against your actual build target, and it trades a stable API for an @ApiStatus.Experimental one that JetBrains may still change.

Contrast with the earlier fixes: runReadAction/invokeLater had drop-in, stable replacements (ReadAction, ApplicationManager…) that exist in 2024.3.6. This one does not.

My recommendation

Leave ElmReviewPass.kt:88 as-is. Revisit it only when the plugin bumps its minimum platformVersion to one that ships CodeInsightContext — and even then weigh the experimental status.

If the strikethrough in your editor bothers you in the meantime, the options are:
1. Do nothing (recommended) — it compiles cleanly and works on both 2024.3 and 2025.3.
2. Add @Suppress("DEPRECATION") to doFinish — silences it, but hides the future signal.
3. Bump platformVersion to 2025.x and adopt the 4-arg experimental API — larger change, drops 2024.3 compatibility.

There are really two different kinds of deprecation in play here, and they deserve different reactions:

The "clean" kind — runReadAction / invokeLater. Marked @ApiStatus.Obsolete, and the replacement (ReadAction, ApplicationManager…invokeLater) has existed and been stable for years, present in every version you support. Migrating is pure upside: same behavior, no compatibility cost. JetBrains is right to push on these.

The awkward kind — markFileUpToDate. Here they flag it in the verifier, but the sanctioned replacement:
- requires CodeInsightContext, a new type that doesn't exist in the very version they also tell you to support (2024.3), and
- is itself @ApiStatus.Experimental — i.e. "we reserve the right to change this again."

So a plugin that supports a normal range (2024.3 → 2025.3) literally cannot satisfy both the verifier and the compiler at once without #if-style version branching. That's the tension: the verifier runs each target IDE independently and reports per-version, but it has no notion of "this plugin must compile against a range." From its point of view every deprecation is actionable; from your point of view, this one isn't yet.

A couple of things worth knowing that take some of the sting out:

- @ApiStatus.Obsolete vs @Deprecated matters. Obsolete = "prefer the new thing in new code," no removal timeline. @Deprecated on the platform is more serious but still usually not removed for a long time, and @ScheduledForRemoval(inVersion=…) is the only one that's a real clock. markFileUpToDate is plain @Deprecated with no removal version — no urgency.
- The email is informational, not a gate. Deprecation usage doesn't fail verification or block Marketplace publishing (only actual incompatibilities do). It's a nudge, and it's fine to knowingly ignore a nudge that isn't yet satisfiable.

</details>

_Note: As you can tell, I created this PR using Claude Code._