### PR TITLE
elm-review improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## [Unreleased]
 *   Fixed: an explicitly imported type now shadows one brought in by a wildcard (`exposing (..)`) import, regardless of import order, matching how values already resolved
 *   The constructor of a phantom type (which is unused on purpose; must be marked with `Never` or the type itself) is no longer marked as unused
+*   Fixed: elm-review is no longer run on files from dependencies (in `~/.elm`)
+*   Fixed: Global elm-review errors now show up in the elm-review panel
 
 ## [6.0.0] - 2026-04-13
 *   Fixed: Reworked the elm-review panel (#19)

--- a/src/main/kotlin/org/elm/ide/annotator/ElmReviewPass.kt
+++ b/src/main/kotlin/org/elm/ide/annotator/ElmReviewPass.kt
@@ -43,6 +43,11 @@ class ElmReviewPass(
     override fun doCollectInformation(progress: ProgressIndicator) {
         if (file !is ElmFile || !isPassEnabled()) return
         val elmProject = file.elmProject ?: return
+        // Only review files that belong to one of the workspace's own Elm projects.
+        // Files opened from a dependency (e.g. go-to-definition into a package in ~/.elm)
+        // resolve to that package's ElmProject, which is not in `allProjects`. Reviewing
+        // such files is never useful.
+        if (elmProject !in file.project.elmWorkspace.allProjects) return
         val pathToListenFor: Path = elmProject.projectDirPath
 
         val service = editor.project?.elmReviewService ?: return

--- a/src/main/kotlin/org/elm/ide/toolwindow/ElmReviewToolWindowFactory.kt
+++ b/src/main/kotlin/org/elm/ide/toolwindow/ElmReviewToolWindowFactory.kt
@@ -18,6 +18,7 @@ import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
+import com.intellij.pom.Navigatable
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindow
@@ -88,17 +89,28 @@ class ElmReviewToolWindowFactory : ToolWindowFactory {
     }
 }
 
+private const val GLOBAL_ERRORS_GROUP = "Global errors"
+
+/**
+ * A [Navigatable] that goes nowhere. Used for global elm-review errors, which are not tied to a
+ * source file and therefore have nothing to jump to when activated in the tree.
+ */
+private object NonNavigatable : Navigatable {
+    override fun navigate(requestFocus: Boolean) {}
+    override fun canNavigate(): Boolean = false
+    override fun canNavigateToSource(): Boolean = false
+}
+
 private fun toIssues(baseDirPath: Path, messages: List<ElmReviewError>): List<ElmReviewIssue> {
-    val issues = mutableListOf<ElmReviewIssue>()
-    messages.forEach { elmReviewError ->
-        val sourceLocation = elmReviewError.path ?: return@forEach
-        val virtualFile = baseDirPath.resolve(sourceLocation).let {
-            LocalFileSystem.getInstance().findFileByPath(it.toString())
+    return messages.map { elmReviewError ->
+        // `path` is null for global errors that aren't tied to a source file; keep them so they
+        // can be shown under the synthetic "Global errors" group instead of being dropped.
+        val sourceLocation = elmReviewError.path
+        val virtualFile = sourceLocation?.let {
+            LocalFileSystem.getInstance().findFileByPath(baseDirPath.resolve(it).toString())
         }
-        val issue = ElmReviewIssue(baseDirPath, sourceLocation, virtualFile, elmReviewError)
-        issues += issue
+        ElmReviewIssue(baseDirPath, sourceLocation, virtualFile, elmReviewError)
     }
-    return issues
 }
 
 private class ElmReviewDetailsPanel(project: Project) : JPanel(BorderLayout()) {
@@ -213,7 +225,7 @@ private class ElmReviewDetailsPanel(project: Project) : JPanel(BorderLayout()) {
 
 private data class ElmReviewIssue(
     val baseDirPath: Path,
-    val sourceLocation: String,
+    val sourceLocation: String?,
     val virtualFile: VirtualFile?,
     val error: ElmReviewError
 ) {
@@ -280,22 +292,26 @@ private class ElmReviewErrorTreeViewPanel(project: Project) : ElmErrorTreeViewPa
             val elmReviewError = issue.error
             val ruleText = elmReviewTreeRuleLabel(elmReviewError, issue.isFixable, showSuppressed)
             val treeMessage = elmReviewTreeMessage(elmReviewError)
-            val location = elmReviewLocation(elmReviewError)
-            if (location == null) {
-                addErrorMessage(
+            if (issue.sourceLocation == null) {
+                // Global errors have no file to group under and nothing to navigate to, so put
+                // them under a synthetic "Global errors" node with a non-navigable entry.
+                addMessage(
                     MessageCategory.SIMPLE,
                     arrayOf("$encodedIndex$ruleText", treeMessage),
-                    issue.virtualFile,
-                    0,
-                    0
+                    GLOBAL_ERRORS_GROUP,
+                    NonNavigatable,
+                    "",
+                    "",
+                    null
                 )
             } else {
+                val location = elmReviewLocation(elmReviewError)
                 addErrorMessage(
                     MessageCategory.SIMPLE,
                     arrayOf("$encodedIndex$ruleText", treeMessage),
                     issue.virtualFile,
-                    location.first,
-                    location.second
+                    location?.first ?: 0,
+                    location?.second ?: 0
                 )
             }
         }
@@ -450,8 +466,9 @@ private class ElmReviewErrorTreeViewPanel(project: Project) : ElmErrorTreeViewPa
         var firstFileToFocus: VirtualFile? = null
         targetIssues.forEach { issue ->
             if (!issue.isFixable) return@forEach
+            val sourceLocation = issue.sourceLocation ?: return@forEach
             val file = issue.virtualFile ?: LocalFileSystem.getInstance()
-                .refreshAndFindFileByPath(issue.baseDirPath.resolve(issue.sourceLocation).toString())
+                .refreshAndFindFileByPath(issue.baseDirPath.resolve(sourceLocation).toString())
                 ?: return@forEach
             val document = FileDocumentManager.getInstance().getDocument(file) ?: return@forEach
             if (firstFileToFocus == null) firstFileToFocus = file

--- a/src/main/kotlin/org/elm/openapiext/Subprocesses.kt
+++ b/src/main/kotlin/org/elm/openapiext/Subprocesses.kt
@@ -53,7 +53,8 @@ fun GeneralCommandLine.execute(
     toolName: String,
     project: Project,
     timeoutInMilliseconds: Int = 3000,
-    stdIn: String? = null
+    stdIn: String? = null,
+    logNonZeroExit: Boolean = true
 ): ProcessOutput {
 
     val handler =
@@ -80,7 +81,7 @@ fun GeneralCommandLine.execute(
     try {
         fun runProcess(): ProcessOutput {
             val output = handler.runProcess(timeoutInMilliseconds)
-            if (output.exitCode != 0) {
+            if (output.exitCode != 0 && logNonZeroExit) {
                 log.warn("Command $toolName exited with code ${output.exitCode}")
             }
             return output

--- a/src/main/kotlin/org/elm/workspace/ElmReviewService.kt
+++ b/src/main/kotlin/org/elm/workspace/ElmReviewService.kt
@@ -127,7 +127,10 @@ class ElmReviewService(private val project: Project) {
                 val output = command.execute(
                     elmReviewTool,
                     project,
-                    timeoutInMilliseconds = 120_000
+                    timeoutInMilliseconds = 120_000,
+                    // A non-zero exit code just means elm-review found errors, which is
+                    // handled below; the generic warning would only be noise.
+                    logNonZeroExit = false
                 )
 
                 val json = extractElmReviewJson(output.stdout, output.stderr)

--- a/src/main/kotlin/org/elm/workspace/elmreview/ElmReviewJsonReport.kt
+++ b/src/main/kotlin/org/elm/workspace/elmreview/ElmReviewJsonReport.kt
@@ -109,7 +109,8 @@ fun JsonReader.readErrorReport(): List<ElmReviewError> {
                             var currentPath: String? = null
                             readProperties { outerProperty ->
                                 when (outerProperty) {
-                                    "path" -> currentPath = nextString()
+                                    // `path` is null for global errors that aren't tied to a source file.
+                                    "path" -> currentPath = readNullableString()
                                     "errors" -> {
                                         beginArray()
                                         while (hasNext()) {
@@ -153,7 +154,7 @@ fun JsonReader.readErrorReport(): List<ElmReviewError> {
                             var currentPath: String? = null
                             readProperties { outerProperty ->
                                 when (outerProperty) {
-                                    "path" -> currentPath = nextString()
+                                    "path" -> currentPath = readNullableString()
                                     "name" -> skipValue()
                                     "problems" -> {
                                         beginArray()

--- a/src/test/kotlin/org/elm/workspace/elmreview/ElmReviewJsonReportTest.kt
+++ b/src/test/kotlin/org/elm/workspace/elmreview/ElmReviewJsonReportTest.kt
@@ -315,6 +315,61 @@ class ElmReviewJsonReportTest : ElmTestBase() {
     }
 
     @Test
+    fun `parses review-errors with null path for a global error`() {
+        // elm-review emits "path": null for global errors (Rule.globalError) that are not
+        // tied to a specific source file. The parser must not assume `path` is always a string.
+        @Language("JSON")
+        val json = """
+{
+  "type": "review-errors",
+  "cliVersion": "2.13.5",
+  "errors": [
+    {
+      "path": null,
+      "errors": [
+        {
+          "rule": "ExampleRule",
+          "message": "Example global rule error",
+          "details": [
+            "Global errors have no path"
+          ],
+          "region": {
+            "start": {
+              "line": 0,
+              "column": 0
+            },
+            "end": {
+              "line": 0,
+              "column": 0
+            }
+          },
+          "formatted": [
+            {
+              "string": "ExampleRule",
+              "color": "#FF0000"
+            },
+            ": Example global rule error\n\nGlobal errors have no path"
+          ],
+          "suppressed": false,
+          "originallySuppressed": false
+        }
+      ]
+    }
+  ]
+}
+        """.trimIndent()
+
+        val reader = JsonReader(json.byteInputStream().bufferedReader())
+        reader.strictness = Strictness.LENIENT
+        val report = reader.readErrorReport()
+
+        TestCase.assertEquals(1, report.size)
+        TestCase.assertNull(report[0].path)
+        TestCase.assertEquals("ExampleRule", report[0].rule)
+        TestCase.assertEquals(ElmReviewErrorOrigin.REVIEW, report[0].origin)
+    }
+
+    @Test
     fun `parses type error`() {
         @Language("JSON")
         val json = """


### PR DESCRIPTION
Here are four elm-review improvements that all stems from me debugging the following exception:

```
 2026-07-24 19:07:05,448 [1058549]   WARN - #org.elm.workspace.ElmReviewService - elm-review run failed
  java.lang.IllegalStateException: Expected a string but was NULL at line 1 column 83 path $.errors[0].path
```

- The first commit makes sure that we don’t run elm-review on files in dependencies. For example, if you go-to-definition to `Maybe.withDefault`, you don’t want elm-review to run with your project rules on that file (in `~/.elm`). Claude said something about that this could only happen if you have configured an absolute path to the elm-review config, which I have.
- The second commit prevents a crash on global elm-review errors. Global errors have no path, but our JSON decoder always expected a string as path. The rest of the code already handled a null path anyway – see the next point.
- The third commit displays global errors in the review panel. Previously, errors with null path were dropped. Now they are shown in a “Global errors” section.
- The fourth commit avoids logging `WARN - org.elm.openapiext.Subprocesses - Command elm-review exited with code 1` every time elm-review finds review errors.

_Note: I made this PR with Claude Code._