### PR TITLE
Remove unnecessary read actions around `project.isDisposed`

### DIFF
--- a/src/main/kotlin/org/elm/openapiext/Subprocesses.kt
+++ b/src/main/kotlin/org/elm/openapiext/Subprocesses.kt
@@ -31,7 +31,6 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
 import com.intellij.execution.process.ProcessOutput
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.util.io.systemIndependentPath
@@ -73,8 +72,7 @@ fun GeneralCommandLine.execute(
             CapturingProcessHandler(this)
         }
 
-    val alreadyDisposed = ReadAction.compute<Boolean, Throwable> { project.isDisposed }
-    if (alreadyDisposed) {
+    if (project.isDisposed) {
         return ProcessOutput().apply { setCancelled() }
     }
 

--- a/src/main/kotlin/org/elm/workspace/commandLineTools/ElmReviewCLI.kt
+++ b/src/main/kotlin/org/elm/workspace/commandLineTools/ElmReviewCLI.kt
@@ -6,7 +6,6 @@ import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.runBackgroundableTask
@@ -55,8 +54,7 @@ class ElmReviewCLI(private val elmReviewExecutablePath: Path) {
                 val handler = CapturingProcessHandler(generalCommandLine)
                 try {
                     val output = handler.runProcess()
-                    val alreadyDisposed = ReadAction.compute<Boolean, Throwable> { project.isDisposed }
-                    if (alreadyDisposed) {
+                    if (project.isDisposed) {
                         throw ExecutionException("External command failed to start")
                     }
                     if (output.exitCode != 0) {


### PR DESCRIPTION
Follow-up on https://github.com/elm-tooling/intellij-elm/pull/68

_Description by Claude Code:_

Drops the `ReadAction.compute { project.isDisposed }` wrappers in `Subprocesses.kt` and `ElmReviewCLI.kt`, replacing them with a plain `project.isDisposed` check.

### Why this is safe

**`Project.isDisposed` does not require a read action.** It's a thread-safe state read (volatile-backed) that the platform allows from any thread. Wrapping it in a read action was never necessary for correctness.

**The read action provided no atomicity anyway.** A read lock does not prevent a project from being disposed — disposal can happen the instant after the block returns. So `alreadyDisposed` was always a best-effort snapshot, wrapped or not. Removing the wrapper does not weaken any guarantee, because there was none to
weaken.

**The wrapper was vestigial.** Git history shows it originally guarded a *compound* operation — introduced in https://github.com/elm-tooling/intellij-elm/commit/54f230033405507a6a350aae2948ad49978d472a:

```kotlin
val alreadyDisposed = runReadAction {
    if (Disposer.isDisposed(owner)) {
        true
    } else {
        Disposer.register(owner, processKiller)
        false
    }
}
```

…where the read action arguably had a purpose (check-then-register). A later refactor — https://github.com/elm-tooling/intellij-elm/commit/96f5ad1b048c0f43ff6add513870ceda91c9306c — removed the Disposer.register side effect and reduced the body to a single project.isDisposed read, but left the read-action wrapper behind. This change finishes that cleanup.