### PR TITLE
Cache ~/.elm in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,10 @@
 
 name: Build
 on:
+  # Trigger the workflow on pushes to only the 'main' branch (this avoids duplicate checks being run e.g. for dependabot pull requests)
   push:
     branches: [main, develop]
+  # Trigger the workflow on any pull request
   pull_request:
 
 concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,8 @@
 
 name: Build
 on:
-  # Trigger the workflow on pushes to only the 'main' branch (this avoids duplicate checks being run e.g. for dependabot pull requests)
   push:
     branches: [main, develop]
-  # Trigger the workflow on any pull request
   pull_request:
 
 concurrency:
@@ -134,11 +132,40 @@ jobs:
       - name: Install elm tools
         run: npm install --global elm elm-test elm-format elm-review lamdera
 
+      # Restore the Elm package cache. Keyed on the dummy projects' manifests, so it is
+      # rebuilt whenever the set of packages/versions they install changes (see
+      # install-packages-for-ci/README.md).
+      - name: Cache Elm packages (~/.elm)
+        uses: actions/cache@v6
+        with:
+          path: ~/.elm
+          key: elm-${{ hashFiles('install-packages-for-ci/*/elm.json') }}
+
+      # Fail early if a test fixture uses a package/version the dummy projects don't install.
+      - name: Verify Elm pre-warm projects are up to date
+        run: ./install-packages-for-ci/verify.sh
+
+      # Pre-populate ~/.elm so the test suite never has to download packages mid-run.
+      # Retried for transient network errors.
+      - name: Pre-warm Elm packages
+        run: |
+          set -uo pipefail
+          warm() {
+            for d in install-packages-for-ci/*/; do
+              ( cd "$d" && elm make ../Main.elm --output=/dev/null )
+            done
+          }
+          for attempt in 1 2 3; do
+            if warm; then exit 0; fi
+            echo "::warning::Pre-warm attempt $attempt failed; retrying in 15s"
+            sleep 15
+          done
+          echo "::error::Failed to pre-warm ~/.elm after 3 attempts"
+          exit 1
+
       # Run tests
       - name: Run Tests
         run: ./gradlew check koverXmlReportJvm
-
-      - run: ls -R ~/.elm
 
       # Collect Tests Result of failed tests
       - name: Collect Tests Result

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,8 @@ jobs:
       - name: Run Tests
         run: ./gradlew check koverXmlReportJvm
 
+      - run: ls -R ~/.elm
+
       # Collect Tests Result of failed tests
       - name: Collect Tests Result
         if: ${{ failure() }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .env
 
 build/
+elm-stuff/
 out/
 dist/
 testData/

--- a/install-packages-for-ci/Main.elm
+++ b/install-packages-for-ci/Main.elm
@@ -1,0 +1,10 @@
+module Main exposing (main)
+
+
+main : Program () () ()
+main =
+    Platform.worker
+        { init = \_ -> ( (), Cmd.none )
+        , update = \_ model -> ( model, Cmd.none )
+        , subscriptions = \_ -> Sub.none
+        }

--- a/install-packages-for-ci/README.md
+++ b/install-packages-for-ci/README.md
@@ -1,0 +1,36 @@
+# Pre-warming `~/.elm` for CI
+
+Many tests read the Elm compiler's global package cache (`~/.elm/<version>/packages/`)
+but do not download into it themselves — that only happens as a side effect of the few
+tests that shell out to the toolchain (`StdlibInstallHelper`, `ElmBuildActionTest`,
+`ElmTestCLITest`, `ElmReviewCLITest`). If one of those downloads flakes over the network,
+or a reader test runs before its installer, hundreds of unrelated tests fail with
+`ProjectLoadException` / `IllegalArgumentException`.
+
+The fix: populate `~/.elm` once, up front, in CI, then let the Actions cache keep it
+warm. These two dummy projects exist only to drive that population.
+
+## How it works in CI (`.github/workflows/build.yml`, `test` job)
+
+1. `actions/cache` restores `~/.elm`, keyed on the hash of every `*/elm.json`.
+2. `verify.sh` fails the build if a `src/` fixture uses a package/version that no
+   dummy project installs (so the cache can never silently go stale).
+3. `elm make ../Main.elm` is run in each bucket subdirectory (with retry). Elm installs
+   everything listed in each `elm.json` before compiling, so this fills `~/.elm` for certain.
+
+## Why more than one project?
+
+Some packages are pinned at **multiple versions** across the fixtures (`elm/core` 1.0.0 &
+1.0.5, `elm/json` 1.0.0 & 1.1.3, `elm/parser` 1.0.0 & 1.1.0). A single `elm.json` can only
+hold one version of each package, so each bucket subdirectory holds one non-conflicting set:
+today `a/` has the older versions and `b/` has everything else. If a fixture ever introduces
+a *third* version of some package, just add a `c/` (etc.) — no code changes needed.
+
+## Updating when a fixture changes
+
+If `verify.sh` fails, it prints the missing `"author/pkg": "version"` entries. Add each to
+the `dependencies.direct` of a bucket that doesn't already pin that package at a different
+version (or create a new bucket subdirectory with its own `elm.json`), then
+run `elm make ../Main.elm` locally in that folder to confirm the solution is valid. Bumping
+the compiler? Update `elm-version` in every bucket to match; that also rotates the cache key.
+`lamdera/*` packages are intentionally excluded — no test compiles the Lamdera fixture.

--- a/install-packages-for-ci/a/elm.json
+++ b/install-packages-for-ci/a/elm.json
@@ -1,0 +1,19 @@
+{
+    "type": "application",
+    "source-directories": [
+        ".."
+    ],
+    "elm-version": "0.19.2",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.0",
+            "elm/json": "1.0.0",
+            "elm/parser": "1.0.0"
+        },
+        "indirect": {}
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/install-packages-for-ci/b/elm.json
+++ b/install-packages-for-ci/b/elm.json
@@ -1,0 +1,29 @@
+{
+    "type": "application",
+    "source-directories": [
+        ".."
+    ],
+    "elm-version": "0.19.2",
+    "dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.0.0",
+            "elm/browser": "1.0.2",
+            "elm/bytes": "1.0.8",
+            "elm/core": "1.0.5",
+            "elm/file": "1.0.5",
+            "elm/html": "1.0.0",
+            "elm/http": "2.0.0",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
+        },
+        "indirect": {}
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/install-packages-for-ci/verify.sh
+++ b/install-packages-for-ci/verify.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Verifies that the dummy Elm projects in this directory install every Elm
+# package + version that the test fixtures under src/ depend on. If a fixture
+# starts using a package/version that neither dummy project installs, the CI
+# `~/.elm` pre-warm would be incomplete and tests could flake, so this fails loudly.
+#
+# See README.md for more details.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Packages the test fixtures need in ~/.elm: every exact "author/pkg": "x.y.z"
+# pin anywhere under src/, minus lamdera/* (the Lamdera fixture is parse-only; no
+# test compiles it, so those packages never end up in ~/.elm).
+needed="$(
+    grep -rhoE '"[A-Za-z0-9_-]+/[A-Za-z0-9_-]+": "[0-9]+\.[0-9]+\.[0-9]+"' src/ \
+        | sed -E 's/"([^"]+)": "([^"]+)"/\1 \2/' \
+        | grep -v '^lamdera/' \
+        | sort -u
+)"
+
+# Packages the dummy projects install (direct + indirect, both dep sections).
+# One elm.json per bucket subdirectory; add more buckets by adding more subdirs.
+provided="$(
+    jq -r '( (.dependencies.direct // {}) + (.dependencies.indirect // {})) | to_entries[] | "\(.key) \(.value)"' \
+        install-packages-for-ci/*/elm.json \
+        | sort -u
+)"
+
+missing="$(comm -23 <(printf '%s\n' "$needed") <(printf '%s\n' "$provided"))"
+
+if [ -n "$missing" ]; then
+    echo "ERROR: the install-packages-for-ci/*/elm.json manifests are out of date."
+    echo
+    echo "These packages are used by test fixtures under src/ but are not installed"
+    echo "by any dummy project, so CI would not pre-warm them into ~/.elm:"
+    echo
+    printf '%s\n' "$missing" | sed 's/^/  - /'
+    echo
+    echo "Add each missing \"author/pkg\": \"version\" to the 'direct' section of one"
+    echo "install-packages-for-ci/*/elm.json (a new bucket subdir if versions conflict;"
+    echo "see README.md)."
+    exit 1
+fi
+
+echo "OK: dummy projects cover all $(printf '%s\n' "$needed" | grep -c . || true) fixture packages."


### PR DESCRIPTION
The Elm package server sometimes has problems. Then packages fail to install and tests fail.

This PR:

- Installs all needed packages into `~/.elm` before running the tests.
- Caches `~/.elm` so the package server isn’t needed at all if the cache is up-to-date.

How do we know which packages are needed in `~/.elm`? This PR adds a script to extract that from the tests.

_Note: This PR was made in collaboration with Claude Code._