### PR TITLE
Only trigger releases on `main`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@
 
 name: Build
 on:
-  # Trigger the workflow on pushes to only the 'main' branch (this avoids duplicate checks being run e.g. for dependabot pull requests)
+  # Trigger the workflow on pushes to only the 'main' and 'develop' branches (this avoids duplicate checks being run e.g. for dependabot pull requests)
   push:
     branches: [main, develop]
   # Trigger the workflow on any pull request
@@ -267,7 +267,13 @@ jobs:
   # - plain semver => full release (published)
   releaseDraft:
     name: Create/Publish Release
-    if: github.event_name != 'pull_request' && (github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip release]'))
+    # Release only on a push to main. A PR build's ref is refs/pull/<n>/merge, so the ref
+    # check alone already excludes pull_request events — no separate event_name check needed.
+    # github.event.head_commit exists only on push events (null otherwise), so the
+    # event_name guard keeps the [skip release] test from being applied where it's meaningless
+    # (e.g. workflow_dispatch). Note it's the *tip* commit only — [skip release] on an earlier
+    # commit in the same push won't be seen.
+    if: github.ref == 'refs/heads/main' && (github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip release]'))
     needs: [ build, test, inspectCode, verify ]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
When merging a PR to `develop`, the `releaseDraft` job runs (and fails). To me it looks like `releaseDraft` was intended to run on `main` only. When ready to release, merge `develop` to `main` and the job runs.