### PR TITLE
Change the icon for the elm-review panel

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -244,7 +244,7 @@
                     factoryClass="org.elm.ide.toolwindow.ElmToolWindowFactory"/>
         <toolWindow id="Elm Compiler" anchor="bottom" icon="/icons/elm-toolwindow.svg"
                     factoryClass="org.elm.ide.toolwindow.ElmCompilerToolWindowFactory"/>
-        <toolWindow id="Elm Review" anchor="bottom" secondary="false" icon="/icons/elm-toolwindow.svg"
+        <toolWindow id="Elm Review" anchor="bottom" secondary="false" icon="/icons/elm-review.svg"
                     factoryClass="org.elm.ide.toolwindow.ElmReviewToolWindowFactory"/>
         <statusBarWidgetFactory
                 id="org.elm.statusBar.tasks"

--- a/src/main/resources/icons/elm-review.svg
+++ b/src/main/resources/icons/elm-review.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600">
+  <polygon fill="#6C707E" points="0,576 280,576 140,334"/>
+  <polygon fill="#6C707E" points="320,576 600,576 460,334"/>
+  <polygon fill="#6C707E" points="160,286 440,286 300,24"/>
+  <polygon fill="#6C707E" points="160,314 440,314 300,556"/>
+</svg>

--- a/src/main/resources/icons/elm-review_dark.svg
+++ b/src/main/resources/icons/elm-review_dark.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600">
+  <polygon fill="#AFB1B3" points="0,576 280,576 140,334"/>
+  <polygon fill="#AFB1B3" points="320,576 600,576 460,334"/>
+  <polygon fill="#AFB1B3" points="160,286 440,286 300,24"/>
+  <polygon fill="#AFB1B3" points="160,314 440,314 300,556"/>
+</svg>


### PR DESCRIPTION
Previously, both the Elm Compiler panel and the elm-review panel buttons used the Elm tangram logo as the icon.

This PR changes the icon for the elm-review panel button to the elm-review logo: A tangram-style triangle.

I made the SVG by hand, by copying the Elm tangram SVG we already had and editing it. The elm-review SVG uses the same colors and the same distance (28 units) between the pieces.

Reference PNG: https://github.com/jfmengels/blog/blob/c1bd29d0b07b15e775805b22cf565dca5fa3a1be/public/images/logo.png

| Before | After |
|-|-|
|<img width="78" height="250" alt="image" src="https://github.com/user-attachments/assets/64fe3ee0-17e8-4abe-873c-019ca4ca93a7" />|<img width="94" height="245" alt="image" src="https://github.com/user-attachments/assets/1577248f-540d-461b-82ed-729de526ab20" />|

I have tested that the new icon works both in light mode and dark mode.