### PR TITLE
Fix elm-review icons not being perfect triangles

### DIFF
--- a/src/main/resources/icons/elm-review.svg
+++ b/src/main/resources/icons/elm-review.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600">
-  <polygon fill="#6C707E" points="0,576 280,576 140,334"/>
-  <polygon fill="#6C707E" points="320,576 600,576 460,334"/>
-  <polygon fill="#6C707E" points="160,286 440,286 300,24"/>
-  <polygon fill="#6C707E" points="160,314 440,314 300,556"/>
+  <polygon fill="#6C707E" points="0,560 276,560 138,321"/>
+  <polygon fill="#6C707E" points="324,560 600,560 462,321"/>
+  <polygon fill="#6C707E" points="162,279 438,279 300,40"/>
+  <polygon fill="#6C707E" points="162,307 438,307 300,546"/>
 </svg>

--- a/src/main/resources/icons/elm-review_dark.svg
+++ b/src/main/resources/icons/elm-review_dark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600">
-  <polygon fill="#AFB1B3" points="0,576 280,576 140,334"/>
-  <polygon fill="#AFB1B3" points="320,576 600,576 460,334"/>
-  <polygon fill="#AFB1B3" points="160,286 440,286 300,24"/>
-  <polygon fill="#AFB1B3" points="160,314 440,314 300,556"/>
+  <polygon fill="#AFB1B3" points="0,560 276,560 138,321"/>
+  <polygon fill="#AFB1B3" points="324,560 600,560 462,321"/>
+  <polygon fill="#AFB1B3" points="162,279 438,279 300,40"/>
+  <polygon fill="#AFB1B3" points="162,307 438,307 300,546"/>
 </svg>


### PR DESCRIPTION
Follow-up on https://github.com/elm-tooling/intellij-elm/pull/76

I made a mistake in my trigonometry, so the outer silhouette of the icon wasn’t a perfect triangle.

I made the following script to generate the icon numbers this time:

```js
b = 600 // Size of art board
r = 28 // Gap between triangles
m = r/2 // Offset y-wise to achieve r
n = r*Math.sqrt(3)/2 // Offset x-wise to achieve r
s = b/2-n // Side of triangle
t = s*Math.sqrt(3)/2 // Height of triangle
p = (b-m-r-2*t)/2 // Padding top and bottom

d = (v) => Math.round(v) // Rounding

svg = `
<svg xmlns="http://www.w3.org/2000/svg" viewBox="${d(0)} ${d(0)} ${d(b)} ${d(b)}">
  <polygon fill="#6C707E" points="${d(0)},${d(b-p)} ${d(s)},${d(b-p)} ${d(s/2)},${d(b-p-t)}"/>
  <polygon fill="#6C707E" points="${d(s+2*n)},${d(b-p)} ${d(s+2*n+s)},${d(b-p)} ${d(s+2*n+s/2)},${d(b-p-t)}"/>
  <polygon fill="#6C707E" points="${d(s/2+n)},${d(p+t)} ${d(s/2+n+s)},${d(p+t)} ${d(b/2)},${d(p)}"/>
  <polygon fill="#6C707E" points="${d(s/2+n)},${d(p+t+r)} ${d(s/2+n+s)},${d(p+t+r)} ${d(b/2)},${d(p+t+r+t)}"/>
</svg>
`.trim()

console.log(svg)
```

In the following screenshots I have added a magenta triangle as background. It is supposed to line up perfectly with the three smaller triangles.

| Before | After |
| - | - |
| <img width="650" height="622" alt="image" src="https://github.com/user-attachments/assets/20428fa2-2a95-466e-ab0e-fff3112ea2c6" /> | <img width="650" height="622" alt="image" src="https://github.com/user-attachments/assets/f1734486-d81d-40f4-b4d7-837903c5b83a" /> |